### PR TITLE
Fix Readthedocs

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,3 +12,8 @@ pytest
 pytest-runner
 numpydoc
 pytest-cov
+
+owslib
+xmltodict
+pandas
+numpy

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ commands=flake8 pydov
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
-    -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_dev.txt
 commands =
     pip install -U pip


### PR DESCRIPTION
Try to fix documentation build on ReadTheDocs.

Add all requirements to requirements_dev, since ReadTheDocs only allows one requirements file and we need installtime requirements too to be able to import the modules to build their documentation.