### PR TITLE
Validate the type of query parameter.

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -193,6 +193,23 @@ class TestBoringSearch(object):
             boringsearch.search(location=(1, 2, 3, 4),
                                 query=query)
 
+    def test_search_both_location_query_wrongquerytype(self, boringsearch):
+        """Test the search method providing both a location and a query,
+        using a query with an invalid type.
+
+        Test whether an InvalidSearchParameterError is raised.
+
+        Parameters
+        ----------
+        boringsearch : pytest.fixture returning pydov.search.BoringSearch
+            An instance of BoringSearch to perform search operations on the DOV
+            type 'Boring'.
+
+        """
+        with pytest.raises(InvalidSearchParameterError):
+            boringsearch.search(location=(1, 2, 3, 4),
+                                query='computer says no')
+
     def test_search(self, mp_wfs, mp_remote_describefeaturetype, mp_remote_md,
                     mp_remote_fc, mp_remote_wfs_feature, mp_boring_xml,
                     boringsearch):
@@ -406,6 +423,22 @@ class TestBoringSearch(object):
 
         with pytest.raises(InvalidFieldError):
             boringsearch.search(query=query)
+
+    def test_search_query_wrongtype(self, boringsearch):
+        """Test the search method with the query parameter using a wrong
+        query type.
+
+        Test whether an InvalidSearchParameterError is raised.
+
+        Parameters
+        ----------
+        boringsearch : pytest.fixture returning pydov.search.BoringSearch
+            An instance of BoringSearch to perform search operations on the DOV
+            type 'Boring'.
+
+        """
+        with pytest.raises(InvalidSearchParameterError):
+            boringsearch.search(query='computer says no')
 
     def test_search_query_wrongfield_returnfield(self, boringsearch):
         """Test the search method with the query parameter using an


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

I added validation on the query parameter type, so we prevent vague xml exceptions and present the user with a more meaningful error.
