### PR TITLE
Add support for requesting extra WFS return_fields.

### DIFF
--- a/examples/boring_search.py
+++ b/examples/boring_search.py
@@ -120,6 +120,20 @@ def get_deep_boreholes_in_bounding_box():
     print(df)
 
 
+def get_borehole_purpose_in_blankenberge():
+    """Get the purpose (doel) of the boreholes in Blankenberge."""
+    from pydov.search import BoringSearch
+    from owslib.fes import PropertyIsEqualTo
+
+    b = BoringSearch()
+    query = PropertyIsEqualTo(propertyname='gemeente', literal='Blankenberge')
+    df = b.search(
+        query=query,
+        return_fields=['pkey_boring', 'doel']
+    )
+    print(df)
+
+
 if __name__ == '__main__':
     # Comment out to skip these examples:
     get_description()
@@ -133,3 +147,4 @@ if __name__ == '__main__':
     # get_groundwater_related_boreholes_in_antwerp()
     # get_boreholes_in_bounding_box()
     # get_deep_boreholes_in_bounding_box()
+    # get_borehole_purpose_in_blankenberge()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -374,26 +374,6 @@ class TestBoringSearch(object):
             boringsearch.search(query=query,
                                 return_fields=('pkey_boring', 'onbestaand'))
 
-    def test_search_wrongreturnfields_queryfield(self, boringsearch):
-        """Test the search method with the query parameter and a query-only
-        field as return field.
-
-        Test whether an InvalidFieldError is raised.
-
-        Parameters
-        ----------
-        boringsearch : pytest.fixture returning pydov.search.BoringSearch
-            An instance of BoringSearch to perform search operations on the DOV
-            type 'Boring'.
-
-        """
-        query = PropertyIsEqualTo(propertyname='boornummer',
-                                  literal='GEO-04/169-BNo-B1')
-
-        with pytest.raises(InvalidFieldError):
-            boringsearch.search(query=query,
-                                return_fields=('pkey_boring', 'doel'))
-
     def test_search_wrongreturnfieldstype(self, boringsearch):
         """Test the search method with the query parameter and a single
         return field as string.
@@ -467,6 +447,27 @@ class TestBoringSearch(object):
 
         with pytest.raises(InvalidFieldError):
             boringsearch.search(query=query)
+
+    def test_search_extrareturnfields(self, mp_remote_describefeaturetype,
+                                      mp_remote_wfs_feature, mp_boring_xml,
+                                      boringsearch):
+        """Test the search method with the query parameter and an extra WFS
+        field as return field.
+
+        Parameters
+        ----------
+        boringsearch : pytest.fixture returning pydov.search.BoringSearch
+            An instance of BoringSearch to perform search operations on the DOV
+            type 'Boring'.
+
+        """
+        query = PropertyIsEqualTo(propertyname='boornummer',
+                                  literal='GEO-04/169-BNo-B1')
+
+        df = boringsearch.search(query=query,
+                                 return_fields=('pkey_boring', 'doel'))
+
+        assert type(df) is DataFrame
 
     def test_search_xmlresolving(self, mp_remote_describefeaturetype,
                                  mp_remote_wfs_feature, mp_boring_xml,

--- a/tests/test_types_boring.py
+++ b/tests/test_types_boring.py
@@ -180,8 +180,13 @@ class TestBoring(object):
                                      'boolean']
 
             if field['source'] == 'wfs':
-                assert sorted(field.keys()) == [
-                    'name', 'source', 'sourcefield', 'type']
+                if 'wfs_injected' in field.keys():
+                    assert sorted(field.keys()) == [
+                        'name', 'source', 'sourcefield', 'type',
+                        'wfs_injected']
+                else:
+                    assert sorted(field.keys()) == [
+                        'name', 'source', 'sourcefield', 'type']
             elif field['source'] == 'xml':
                 assert 'definition' in field
                 assert type(field['definition']) in (str, unicode)
@@ -266,7 +271,8 @@ class TestBoring(object):
         boring = Boring.from_wfs_element(
             wfs_feature, 'http://dov.vlaanderen.be/ocdov/dov-pub')
 
-        fields = Boring.get_fields()
+        fields = [f for f in Boring.get_fields().values() if not f.get(
+            'wfs_injected', False)]
 
         df_array = boring.get_df_array()
         assert type(df_array) is list
@@ -275,7 +281,7 @@ class TestBoring(object):
         for record in df_array:
             assert len(record) == len(fields)
 
-            for value, field in zip(record, fields.values()):
+            for value, field in zip(record, fields):
                 if field['type'] == 'string':
                     assert type(value) in (str, unicode)
                 elif field['type'] == 'float':


### PR DESCRIPTION
This commit allows the user to specify WFS fields as return_fields, even if
they are not part of the default dataframe for the corresponding type.

Closes #47 

<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
