### PR TITLE
adjust xml string encoding 

### DIFF
--- a/pydov/types/abstract.py
+++ b/pydov/types/abstract.py
@@ -56,7 +56,7 @@ class AbstractCommon(object):
         """
         if returntype == 'string':
             def typeconvert(x):
-                return str(x.encode("utf-8") ).strip()
+                return str(x.encode('latin-1') ).strip()
         elif returntype == 'integer':
             def typeconvert(x):
                 return int(x)


### PR DESCRIPTION
adjust xml string encoding to 'latin-1', because 'utf-8' still yields errors

<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.

Describe your fixes/additions/changes
see #69 