### PR TITLE
Fix encoding issue in WFS GetFeature

### DIFF
--- a/pydov/types/abstract.py
+++ b/pydov/types/abstract.py
@@ -58,7 +58,7 @@ class AbstractCommon(object):
         """
         if returntype == 'string':
             def typeconvert(x):
-                return str(x).strip()
+                return x.strip()
         elif returntype == 'integer':
             def typeconvert(x):
                 return int(x)

--- a/pydov/util/owsutil.py
+++ b/pydov/util/owsutil.py
@@ -543,4 +543,5 @@ def wfs_get_feature(baseurl, get_feature_request):
     """
     data = etree.tostring(get_feature_request)
     request = requests.post(baseurl, data)
+    request.encoding = 'utf-8'
     return request.text.encode('utf8')

--- a/tests/abstract.py
+++ b/tests/abstract.py
@@ -2,10 +2,40 @@ import datetime
 import numpy as np
 from collections import OrderedDict
 
+import requests
 from numpy.compat import unicode
 from pandas.api.types import (
     is_int64_dtype, is_object_dtype,
     is_bool_dtype, is_float_dtype)
+
+
+def service_ok(url='https://www.dov.vlaanderen.be/geoserver', timeout=5):
+    """Check whether the given URL is accessible.
+
+    Used to skip online tests when the service is unavailable or unreachable.
+
+    Parameters
+    ----------
+    url : str, optional
+        The URL to test. Defaults to the DOV Geoserver.
+    timeout : int, optional
+        Timeout in seconds. Defaults to 5.
+
+    Returns
+    -------
+    bool
+        True if the service is reachable, False otherwise.
+
+    """
+    try:
+        ok = requests.get(url, timeout=timeout).ok
+    except requests.exceptions.ReadTimeout:
+        ok = False
+    except requests.exceptions.ConnectTimeout:
+        ok = False
+    except Exception:
+        ok = False
+    return ok
 
 
 class AbstractTestSearch(object):

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -29,4 +29,4 @@ class TestEncoding(AbstractTestSearch):
         df = boringsearch.search(query=query,
                                  return_fields=('pkey_boring', 'uitvoerder'))
 
-        assert df.uitvoerder[0] == 'Societé Belge des Bétons'
+        assert df.uitvoerder[0] == u'Societé Belge des Bétons'

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+
+import pytest
+
+from owslib.fes import PropertyIsEqualTo
+from pydov.search.boring import BoringSearch
+from tests.abstract import (
+    AbstractTestSearch,
+    service_ok,
+)
+
+
+class TestEncoding(AbstractTestSearch):
+    """Class grouping tests related to encoding issues."""
+
+    @pytest.mark.online
+    @pytest.mark.skipif(not service_ok(), reason="DOV service is unreachable")
+    def test_search(self):
+        """Test the search method with strange character in the output.
+
+        Test whether the output has the correct encoding.
+
+        """
+        boringsearch = BoringSearch()
+        query = PropertyIsEqualTo(
+            propertyname='pkey_boring',
+            literal='https://www.dov.vlaanderen.be/data/boring/1928-031159')
+
+        df = boringsearch.search(query=query,
+                                 return_fields=('pkey_boring', 'uitvoerder'))
+
+        assert df.uitvoerder[0] == 'Societé Belge des Bétons'


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Fixes issue #69 regarding encoding issues with the WFS GetFeature call, both in Python2.7 and Python3.

Includes an online test for the issue, in favor of offline tests using monkeypatching. This to avoid testing the encoding of our testdata and patching implementation..
