### PR TITLE
Fix using fields from a subtype as return fields.

### DIFF
--- a/pydov/types/abstract.py
+++ b/pydov/types/abstract.py
@@ -520,8 +520,7 @@ class AbstractDovType(AbstractCommon):
 
         """
         fields = self.get_field_names(return_fields)
-        ownfields = self.get_field_names(include_subtypes=False,
-                                         return_fields=return_fields)
+        ownfields = self.get_field_names(include_subtypes=False)
         subfields = [f for f in fields if f not in ownfields]
 
         if len(subfields) > 0:

--- a/tests/test_search_boring.py
+++ b/tests/test_search_boring.py
@@ -365,6 +365,36 @@ class TestBoringSearch(AbstractTestSearch):
         assert list(df) == ['pkey_boring', 'boornummer', 'diepte_boring_tot',
                             'datum_aanvang']
 
+    def test_search_returnfields_subtype(self, mp_remote_wfs_feature,
+                                         boringsearch):
+        """Test the search method with the query parameter and a selection of
+        return fields, including fields from a subtype.
+
+        Test whether the output dataframe contains only the selected return
+        fields.
+
+        Parameters
+        ----------
+        mp_remote_wfs_feature : pytest.fixture
+            Monkeypatch the call to get WFS features.
+        boringsearch : pytest.fixture returning pydov.search.BoringSearch
+            An instance of BoringSearch to perform search operations on the DOV
+            type 'Boring'.
+
+        """
+        query = PropertyIsEqualTo(propertyname='boornummer',
+                                  literal='GEO-04/169-BNo-B1')
+
+        df = boringsearch.search(query=query,
+                                 return_fields=('pkey_boring', 'boornummer',
+                                                'diepte_methode_van',
+                                                'diepte_methode_tot'))
+
+        assert type(df) is DataFrame
+
+        assert list(df) == ['pkey_boring', 'boornummer', 'diepte_methode_van',
+                            'diepte_methode_tot']
+
     def test_search_returnfields_order(self, mp_remote_wfs_feature,
                                        boringsearch):
         """Test the search method with the query parameter and a selection of

--- a/tests/test_search_grondwaterfilter.py
+++ b/tests/test_search_grondwaterfilter.py
@@ -380,6 +380,37 @@ class TestGrondwaterFilterSearch(AbstractTestSearch):
 
         assert list(df) == ['pkey_filter', 'gw_id', 'filternummer']
 
+    def test_search_returnfields_subtype(self, mp_remote_wfs_feature,
+                                         grondwaterfiltersearch):
+        """Test the search method with the query parameter and a selection of
+        return fields, including fields from a subtype.
+
+        Test whether the output dataframe contains only the selected return
+        fields.
+
+        Parameters
+        ----------
+        mp_remote_wfs_feature : pytest.fixture
+            Monkeypatch the call to get WFS features.
+        grondwaterfiltersearch : pytest.fixture returning
+            pydov.search.GrondwaterFilterSearch
+            An instance of GrondwaterFilterSearch to perform search operations
+            on the DOV type 'GrondwaterFilter'.
+
+        """
+        query = PropertyIsEqualTo(propertyname='filterfiche',
+                                  literal='https://www.dov.vlaanderen.be/'
+                                          'data/filter/2003-004471')
+
+        df = grondwaterfiltersearch.search(
+            query=query, return_fields=('pkey_filter', 'gw_id',
+                                        'filternummer', 'peil_mtaw'))
+
+        assert type(df) is DataFrame
+
+        assert list(df) == ['pkey_filter', 'gw_id', 'filternummer',
+                            'peil_mtaw']
+
     def test_search_returnfields_order(self, mp_remote_wfs_feature,
                                        grondwaterfiltersearch):
         """Test the search method with the query parameter and a selection of


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Fix the use of fields from subtypes as return fields.

Closes #78 
