### PR TITLE
Fix rendering borehole format table

### DIFF
--- a/docs/df_format.rst
+++ b/docs/df_format.rst
@@ -211,6 +211,7 @@ the 'methode_van'/'methode_tot' of the Borehole:
     AND interpretation["van"] >= boring["methode_van"]
     AND interpretation["tot"] <= boring["methode_tot"]
 
+|
 
   .. csv-table:: Boringen
     :header-rows: 1


### PR DESCRIPTION
Minimal fix to make sure the table of boreholes: https://pydov.readthedocs.io/en/documentation/df_format.html#boreholes-in-dutch-boring is rendered properly