### PR TITLE
Disable default (progress) hook while testing.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,12 @@
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
+import pydov
+
+
+def pytest_runtest_setup():
+    pydov.hooks = []
+
 
 @pytest.fixture(scope='module')
 def monkeymodule():


### PR DESCRIPTION
To prevent unnecessary progress output in the test output, disable the default hooks while running tests.