### PR TITLE
Fix crash when XML document is invalid

### DIFF
--- a/pydov/types/abstract.py
+++ b/pydov/types/abstract.py
@@ -19,31 +19,6 @@ class AbstractCommon(object):
     """Class grouping methods common to AbstractDovType and
     AbstractDovSubType."""
 
-    def _parse_xml_data(self):
-        """Get remote XML data for this DOV object, parse the raw XML and
-        save the results in the data object.
-
-        Raises
-        ------
-        NotImplementedError
-            This is an abstract method that should be implemented in a
-            subclass.
-
-        """
-        xml = self._get_xml_data()
-        tree = etree.fromstring(xml)
-
-        for field in self.get_fields(source=('xml',),
-                                     include_subtypes=False).values():
-            self.data[field['name']] = self._parse(
-                func=tree.findtext,
-                xpath=field['sourcefield'],
-                namespace=None,
-                returntype=field.get('type', None)
-            )
-
-        self._parse_subtypes(xml)
-
     @classmethod
     def _parse(cls, func, xpath, namespace, returntype):
         """Parse the result of an XML path function, stripping the namespace
@@ -283,6 +258,31 @@ class AbstractDovType(AbstractCommon):
         )
 
         self.data['pkey_%s' % self.typename] = self.pkey
+
+    def _parse_xml_data(self):
+        """Get remote XML data for this DOV object, parse the raw XML and
+        save the results in the data object.
+
+        Raises
+        ------
+        NotImplementedError
+            This is an abstract method that should be implemented in a
+            subclass.
+
+        """
+        xml = self._get_xml_data()
+        tree = etree.fromstring(xml)
+
+        for field in self.get_fields(source=('xml',),
+                                     include_subtypes=False).values():
+            self.data[field['name']] = self._parse(
+                func=tree.findtext,
+                xpath=field['sourcefield'],
+                namespace=None,
+                returntype=field.get('type', None)
+            )
+
+        self._parse_subtypes(xml)
 
     @classmethod
     def from_wfs_element(cls, feature, namespace):

--- a/pydov/util/caching.py
+++ b/pydov/util/caching.py
@@ -8,7 +8,7 @@ import tempfile
 from io import open
 
 import pydov
-from owslib.util import openURL
+from pydov.util.dovutil import get_dov_xml
 
 
 class TransparentCache(object):
@@ -155,9 +155,10 @@ class TransparentCache(object):
             The raw XML data of this DOV object as bytes.
 
         """
+        xml = get_dov_xml(url)
         for hook in pydov.hooks:
             hook.xml_downloaded(url.rstrip('.xml'))
-        return openURL(url).read()
+        return xml
 
     def get(self, url):
         """Get the XML data for the DOV object referenced by the given URL.

--- a/pydov/util/dovutil.py
+++ b/pydov/util/dovutil.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""Module grouping utility functions for DOV XML services."""
+import requests
+
+from owslib.etree import etree
+from pydov.util.errors import XmlParseError
+
+
+def get_dov_xml(url):
+    """Request the XML from the remote DOV webservices and return it.
+
+    Parameters
+    ----------
+    url : str
+        URL of the DOV object to download.
+
+    Returns
+    -------
+    xml : bytes
+        The raw XML data of this DOV object as bytes.
+
+    """
+    request = requests.get(url, timeout=60)
+    request.encoding = 'utf-8'
+    return request.text.encode('utf8')
+
+
+def parse_dov_xml(xml_data):
+    """Parse the given XML data into an ElemenTree.
+
+    Parameters
+    ----------
+    xml_data : bytes
+        The raw XML data of a DOV object as bytes.
+
+    Returns
+    -------
+    tree : etree.ElementTree
+        Parsed XML tree of the DOV object.
+
+    """
+    try:
+        parser = etree.XMLParser(ns_clean=True, recover=True)
+    except TypeError:
+        parser = etree.XMLParser()
+
+    try:
+        tree = etree.fromstring(xml_data, parser=parser)
+        return tree
+    except Exception:
+        raise XmlParseError("Failed to parse XML record.")

--- a/pydov/util/dovutil.py
+++ b/pydov/util/dovutil.py
@@ -2,6 +2,7 @@
 """Module grouping utility functions for DOV XML services."""
 import requests
 
+import pydov
 from owslib.etree import etree
 from pydov.util.errors import XmlParseError
 
@@ -20,7 +21,9 @@ def get_dov_xml(url):
         The raw XML data of this DOV object as bytes.
 
     """
-    request = requests.get(url, timeout=60)
+    headers = {'user-agent': 'PyDOV/%s' % pydov.__version__}
+
+    request = requests.get(url, headers=headers, timeout=60)
     request.encoding = 'utf-8'
     return request.text.encode('utf8')
 

--- a/pydov/util/errors.py
+++ b/pydov/util/errors.py
@@ -37,3 +37,18 @@ class InvalidSearchParameterError(DOVError):
 class InvalidFieldError(DOVError):
     """Error that occurs when using a field outside its scope."""
     pass
+
+
+class XmlParseError(DOVError):
+    """Error that occurs when the parsing of a DOV XML document failed."""
+    pass
+
+
+class DOVWarning(Warning):
+    """General warning in PyDOV."""
+    pass
+
+
+class XmlParseWarning(DOVWarning):
+    """Emitted when the failure to parse an XML document results in
+    an incomplete dataframe."""

--- a/pydov/util/owsutil.py
+++ b/pydov/util/owsutil.py
@@ -20,7 +20,8 @@ except ImportError:
 from owslib.etree import etree
 from owslib.iso import MD_Metadata
 from owslib.namespaces import Namespaces
-from owslib.util import (nspath_eval,
+from owslib.util import (
+    nspath_eval,
     findall,
 )
 

--- a/pydov/util/owsutil.py
+++ b/pydov/util/owsutil.py
@@ -2,6 +2,7 @@
 """Module grouping utility functions for OWS services."""
 import requests
 
+import pydov
 from owslib.feature.schema import (
     _get_describefeaturetype_url,
     _get_elements,
@@ -19,9 +20,7 @@ except ImportError:
 from owslib.etree import etree
 from owslib.iso import MD_Metadata
 from owslib.namespaces import Namespaces
-from owslib.util import (
-    openURL,
-    nspath_eval,
+from owslib.util import (nspath_eval,
     findall,
 )
 
@@ -59,7 +58,7 @@ def __get_remote_md(md_url):
         Response containing the remote metadata.
 
     """
-    return openURL(md_url).read()
+    return get_url(md_url)
 
 
 def __get_remote_fc(fc_url):
@@ -77,7 +76,7 @@ def __get_remote_fc(fc_url):
         Response containing the remote feature catalogue.
 
     """
-    return openURL(fc_url).read()
+    return get_url(fc_url)
 
 
 def __get_remote_describefeaturetype(describefeaturetype_url):
@@ -95,7 +94,7 @@ def __get_remote_describefeaturetype(describefeaturetype_url):
         Response containing the remote DescribeFeatureType.
 
     """
-    return openURL(describefeaturetype_url).read()
+    return get_url(describefeaturetype_url)
 
 
 def get_remote_metadata(contentmetadata):
@@ -397,7 +396,7 @@ def _construct_schema(elements, nsmap):
 
 def get_remote_schema(url, typename, version='1.0.0'):
     """Copy the owslib.feature.schema.get_schema method to be able to
-    monkeypatch the openURL request in tests.
+    monkeypatch the request in tests.
 
     Parameters
     ----------
@@ -542,6 +541,29 @@ def wfs_get_feature(baseurl, get_feature_request):
 
     """
     data = etree.tostring(get_feature_request)
-    request = requests.post(baseurl, data, timeout=60)
+    headers = {'user-agent': 'PyDOV/%s' % pydov.__version__}
+
+    request = requests.post(baseurl, data, headers=headers, timeout=60)
+    request.encoding = 'utf-8'
+    return request.text.encode('utf8')
+
+
+def get_url(url):
+    """Perform a GET request to an OWS service an return the result.
+
+    Parameters
+    ----------
+    url : str
+        URL to request.
+
+    Returns
+    -------
+    bytes
+        Response containing the result of the GET request.
+
+    """
+    headers = {'user-agent': 'PyDOV/%s' % pydov.__version__}
+
+    request = requests.get(url, headers=headers, timeout=60)
     request.encoding = 'utf-8'
     return request.text.encode('utf8')

--- a/pydov/util/owsutil.py
+++ b/pydov/util/owsutil.py
@@ -542,6 +542,6 @@ def wfs_get_feature(baseurl, get_feature_request):
 
     """
     data = etree.tostring(get_feature_request)
-    request = requests.post(baseurl, data)
+    request = requests.post(baseurl, data, timeout=60)
     request.encoding = 'utf-8'
     return request.text.encode('utf8')

--- a/tests/data/encoding/invalidcharacters.xml
+++ b/tests/data/encoding/invalidcharacters.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns3:dov-schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns3="http://kern.schemas.dov.vlaanderen.be" xsi:schemaLocation="http://kern.schemas.dov.vlaanderen.be https://www.dov.vlaanderen.be/xdov/schema/latest/xsd/kern/dov.xsd">
+    <interpretaties>
+        <lithologischebeschrijving>
+            <boring>kb24d60e-B255</boring>
+            <auteur>
+                <persoon>
+                    <naam>Onbekend</naam>
+                </persoon>
+                <bedrijf-dienst>
+                    <naam>bedrijf-dienst onbekend</naam>
+                </bedrijf-dienst>
+            </auteur>
+            <datum>1987-12-08</datum>
+            <betrouwbaarheid>goed</betrouwbaarheid>
+            <dataleverancier>
+                <naam>onbekend</naam>
+            </dataleverancier>
+            <laag>
+                <van>0.00</van>
+                <tot>5.00</tot>
+                <beschrijving>bruin lemig tot kleiig bodemmateriaal gemengd met grof groen zand, niet kalkhoudend</beschrijving>
+            </laag>
+            <laag>
+                <van>5.00</van>
+                <tot>33.00</tot>
+                <beschrijving>homogene groene zanden bestaande uit kwarts en glauconiet, niet kalkhoudend en geen macrofauna, kleiig aspect bij 10 en 30m ook ijzerzandsteenbrokjes</beschrijving>
+            </laag>
+            <laag>
+                <van>33.00</van>
+                <tot>64.00</tot>
+                <beschrijving>zelfde zand met kleiig aspect, kleur wordt donkerdertot zwart; glauconietgehalte wordt groter, geen duidelijke korrelgrootte variaties vast te stellen</beschrijving>
+            </laag>
+            <laag>
+                <van>64.00</van>
+                <tot>65.00</tot>
+                <beschrijving>bruine, zwarte, plastische klei</beschrijving>
+            </laag>
+        </lithologischebeschrijving>
+    </interpretaties>
+</ns3:dov-schema>

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -52,6 +52,11 @@ class TestEncoding(object):
 
         Test whether the output has the correct encoding.
 
+        Parameters
+        ----------
+        nocache : pytest.fixture
+            Fixture to disable caching.
+
         """
         boringsearch = BoringSearch()
         query = PropertyIsEqualTo(
@@ -207,7 +212,24 @@ class TestEncoding(object):
 
         If lxml is installed, the XML should parse regardless of invalid
         characters. If lxml is not installed, the dataframe should be
-        returned with
+        returned with a warning that it will be incomplete.
+
+        Parameters
+        ----------
+        mp_wfs : pytest.fixture
+            Monkeypatch the call to the remote GetCapabilities request.
+        mp_remote_describefeaturetype : pytest.fixture
+            Monkeypatch the call to a remote DescribeFeatureType.
+        mp_remote_md : pytest.fixture
+            Monkeypatch the call to get the remote metadata.
+        mp_remote_fc : pytest.fixture
+            Monkeypatch the call to get the remote feature catalogue.
+        mp_remote_wfs_feature : pytest.fixture
+            Monkeypatch the call to get WFS features.
+        mp_dov_xml : pytest.fixture
+            Monkeypatch the call to get the remote XML data.
+        nocache : pytest.fixture
+            Fixture to disable caching.
 
         """
         lithosearch = LithologischeBeschrijvingenSearch()


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

If the user has lxml installed, we try parsing the XML documents with the 'recover' option to parse even invalid documents.

If lxml is not installed we have to rely on the default Python XML library which does not support the 'recover' option. In this case we cannot parse invalid XML documents and have to set the dataframe columns relying on XML information to 'nan'. We warn the user that the returned dataframe is incomplete.

Closes #110 