### PR TITLE
 Request remote schema in WFS version 1.1.0. 

### DIFF
--- a/pydov/search/abstract.py
+++ b/pydov/search/abstract.py
@@ -117,7 +117,7 @@ class AbstractSearch(object):
         layername = self._layer.split(':')[1] if ':' in self._layer else \
             self._layer
         return get_remote_schema(
-            'https://www.dov.vlaanderen.be/geoserver/wfs', layername)
+            'https://www.dov.vlaanderen.be/geoserver/wfs', layername, '1.1.0')
 
     def _get_namespace(self):
         """Get the WFS namespace of the layer.

--- a/pydov/util/caching.py
+++ b/pydov/util/caching.py
@@ -39,7 +39,7 @@ class TransparentCache(object):
         self.max_age = max_age
 
         self._re_type_key = re.compile(
-            r'https?://www.dov.vlaanderen.be/data/([' '^/]+)/([^\.]+)')
+            r'https?://www\.dov\.vlaanderen\.be/data/([^ /]+)/([^.]+)')
 
         try:
             if not os.path.exists(self.cachedir):


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

To align with other PyDOV requests using WFS version 1.1.0, we should request the schema (i.e. WFS DescribeFeatureType) in version 1.1.0 too instead of the default 1.0.0.

Also: rewrite the type_key regex to comply with new warnings (W605 invalid escape sequence) in flake8 3.6.0
