### PR TITLE
Use gzip to compress cached xml files

### DIFF
--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -47,18 +47,18 @@ your own cache, as follows::
 
     import pydov.util.caching
 
-    pydov.cache = pydov.util.caching.TransparentCache(
+    pydov.cache = pydov.util.caching.GzipTextFileCache(
         cachedir=r'C:\temp\pydov'
     )
 
 Besides controlling the cache's location, this also allows using a different
 cache in different scripts or projects.
 
-Mind that xmls are stored by search type because permalinks are not unique
+Mind that xmls are stored by search type because object keys are not unique
 across types. Therefore, the dir structure of the cache will look like, e.g.::
 
-    ...\pydov\boring\filename.xml
-    ...\pydov\filter\filename.xml
+    ...\pydov\boring\filename.xml.gz
+    ...\pydov\filter\filename.xml.gz
 
 
 Changing the maximum age of cached data
@@ -71,7 +71,7 @@ be considered valid for the current runtime::
     import pydov.util.caching
     import datetime
 
-    pydov.cache = pydov.util.caching.TransparentCache(
+    pydov.cache = pydov.util.caching.GzipTextFileCache(
         max_age=datetime.timedelta(days=1)
     )
 

--- a/docs/notebooks/caching.ipynb
+++ b/docs/notebooks/caching.ipynb
@@ -126,10 +126,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[000/110] ..................................................\n",
-      "[050/110] ..................................................\n",
-      "[100/110] ..........\n",
-      "Wall time: 35.8 s\n"
+      "[000/111] ..................................................\n",
+      "[050/111] ..................................................\n",
+      "[100/111] ...........\n",
+      "Wall time: 38.4 s\n"
      ]
     }
    ],
@@ -149,8 +149,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('number of files: ', 110)\n",
-      "('files present: ', ['1879-119364.xml', '1879-121292.xml', '1879-121293.xml', '1879-121387.xml', '1879-121401.xml', '1879-121412.xml', '1879-121424.xml', '1879-122256.xml', '1894-121258.xml', '1894-122153.xml', '1894-122154.xml', '1894-122155.xml', '1895-121232.xml', '1895-121241.xml', '1895-121242.xml', '1895-121244.xml', '1895-121247.xml', '1895-121248.xml', '1923-121199.xml', '1923-121200.xml', '1932-121315.xml', '1936-122224.xml', '1938-121359.xml', '1938-121360.xml', '1953-121327.xml', '1953-121361.xml', '1953-121362.xml', '1969-033206.xml', '1969-033207.xml', '1969-033208.xml', '1969-033209.xml', '1969-033211.xml', '1969-033212.xml', '1969-033213.xml', '1969-033214.xml', '1969-033215.xml', '1969-033216.xml', '1969-033217.xml', '1969-033218.xml', '1969-033219.xml', '1969-033220.xml', '1969-092685.xml', '1969-092686.xml', '1969-092687.xml', '1969-092688.xml', '1969-092689.xml', '1970-018757.xml', '1970-018762.xml', '1970-018763.xml', '1970-061362.xml', '1970-061363.xml', '1970-061364.xml', '1970-061365.xml', '1970-061366.xml', '1970-061442.xml', '1970-061443.xml', '1970-061444.xml', '1970-061445.xml', '1970-061446.xml', '1970-061447.xml', '1970-061450.xml', '1970-061454.xml', '1970-104897.xml', '1970-104898.xml', '1970-104899.xml', '1970-104900.xml', '1973-018152.xml', '1973-060207.xml', '1973-060208.xml', '1973-081811.xml', '1973-104723.xml', '1973-104727.xml', '1973-104728.xml', '1974-010351.xml', '1975-010345.xml', '1976-014856.xml', '1976-015297.xml', '1976-015298.xml', '1976-015779.xml', '1976-015780.xml', '1976-015781.xml', '1976-015782.xml', '1978-012352.xml', '1978-121458.xml', '1984-081833.xml', '1984-081834.xml', '1985-084552.xml', '1986-005594.xml', '1986-005596.xml', '1986-005597.xml', '1986-005598.xml', '1986-059814.xml', '1986-059815.xml', '1986-059816.xml', '1987-119382.xml', '1996-021717.xml', '1996-081802.xml', '2017-148854.xml', '2017-152011.xml', '2017-153161.xml', '2018-153957.xml', '2018-154057.xml', '2018-155266.xml', '2018-155580.xml', '2018-156632.xml', '2018-156633.xml', '2018-156634.xml', '2018-157193.xml', '2018-157294.xml', '2018-157386.xml'])\n"
+      "('number of files: ', 111)\n",
+      "('files present: ', ['1879-119364.xml.gz', '1879-121292.xml.gz', '1879-121293.xml.gz', '1879-121387.xml.gz', '1879-121401.xml.gz', '1879-121412.xml.gz', '1879-121424.xml.gz', '1879-122256.xml.gz', '1894-121258.xml.gz', '1894-122153.xml.gz', '1894-122154.xml.gz', '1894-122155.xml.gz', '1895-121232.xml.gz', '1895-121241.xml.gz', '1895-121242.xml.gz', '1895-121244.xml.gz', '1895-121247.xml.gz', '1895-121248.xml.gz', '1923-121199.xml.gz', '1923-121200.xml.gz', '1932-121315.xml.gz', '1936-122224.xml.gz', '1938-121359.xml.gz', '1938-121360.xml.gz', '1953-121327.xml.gz', '1953-121361.xml.gz', '1953-121362.xml.gz', '1969-033206.xml.gz', '1969-033207.xml.gz', '1969-033208.xml.gz', '1969-033209.xml.gz', '1969-033211.xml.gz', '1969-033212.xml.gz', '1969-033213.xml.gz', '1969-033214.xml.gz', '1969-033215.xml.gz', '1969-033216.xml.gz', '1969-033217.xml.gz', '1969-033218.xml.gz', '1969-033219.xml.gz', '1969-033220.xml.gz', '1969-092685.xml.gz', '1969-092686.xml.gz', '1969-092687.xml.gz', '1969-092688.xml.gz', '1969-092689.xml.gz', '1970-018757.xml.gz', '1970-018762.xml.gz', '1970-018763.xml.gz', '1970-061362.xml.gz', '1970-061363.xml.gz', '1970-061364.xml.gz', '1970-061365.xml.gz', '1970-061366.xml.gz', '1970-061442.xml.gz', '1970-061443.xml.gz', '1970-061444.xml.gz', '1970-061445.xml.gz', '1970-061446.xml.gz', '1970-061447.xml.gz', '1970-061450.xml.gz', '1970-061454.xml.gz', '1970-104897.xml.gz', '1970-104898.xml.gz', '1970-104899.xml.gz', '1970-104900.xml.gz', '1973-018152.xml.gz', '1973-060207.xml.gz', '1973-060208.xml.gz', '1973-081811.xml.gz', '1973-104723.xml.gz', '1973-104727.xml.gz', '1973-104728.xml.gz', '1974-010351.xml.gz', '1975-010345.xml.gz', '1976-014856.xml.gz', '1976-015297.xml.gz', '1976-015298.xml.gz', '1976-015779.xml.gz', '1976-015780.xml.gz', '1976-015781.xml.gz', '1976-015782.xml.gz', '1978-012352.xml.gz', '1978-121458.xml.gz', '1984-081833.xml.gz', '1984-081834.xml.gz', '1985-084552.xml.gz', '1986-005594.xml.gz', '1986-005596.xml.gz', '1986-005597.xml.gz', '1986-005598.xml.gz', '1986-059814.xml.gz', '1986-059815.xml.gz', '1986-059816.xml.gz', '1987-119382.xml.gz', '1996-021717.xml.gz', '1996-081802.xml.gz', '2017-148854.xml.gz', '2017-152011.xml.gz', '2017-153161.xml.gz', '2018-153957.xml.gz', '2018-154057.xml.gz', '2018-155266.xml.gz', '2018-155580.xml.gz', '2018-156632.xml.gz', '2018-156633.xml.gz', '2018-156634.xml.gz', '2018-157193.xml.gz', '2018-157294.xml.gz', '2018-157386.xml.gz', '2019-160294.xml.gz'])\n"
      ]
     }
    ],
@@ -178,10 +178,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[000/110] cccccccccccccccccccccccccccccccccccccccccccccccccc\n",
-      "[050/110] cccccccccccccccccccccccccccccccccccccccccccccccccc\n",
-      "[100/110] cccccccccc\n",
-      "Wall time: 1.07 s\n"
+      "[000/111] cccccccccccccccccccccccccccccccccccccccccccccccccc\n",
+      "[050/111] cccccccccccccccccccccccccccccccccccccccccccccccccc\n",
+      "[100/111] ccccccccccc\n",
+      "Wall time: 980 ms\n"
      ]
     }
    ],
@@ -221,7 +221,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('number of files: ', 110)\n"
+      "('number of files: ', 111)\n"
      ]
     }
    ],
@@ -276,7 +276,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('number of files: ', 110)\n"
+      "('number of files: ', 111)\n"
      ]
     }
    ],
@@ -336,7 +336,7 @@
    "source": [
     "import pydov.util.caching\n",
     "\n",
-    "pydov.cache = pydov.util.caching.TransparentCache(\n",
+    "pydov.cache = pydov.util.caching.GzipTextFileCache(\n",
     "    cachedir=r'C:\\temp\\pydov'\n",
     "    )"
    ]
@@ -362,7 +362,9 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# for the sake of the example, change dir location back \n",
@@ -402,7 +404,7 @@
    "source": [
     "import pydov.util.caching\n",
     "import datetime\n",
-    "pydov.cache = pydov.util.caching.TransparentCache(\n",
+    "pydov.cache = pydov.util.caching.GzipTextFileCache(\n",
     "    max_age=datetime.timedelta(seconds=1)\n",
     "    )\n",
     "print(pydov.cache.max_age)"
@@ -417,13 +419,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1879-119364.xml\n"
+      "1879-119364.xml.gz\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'Tue Oct 30 16:16:34 2018'"
+       "'Wed Mar 06 14:36:24 2019'"
       ]
      },
      "execution_count": 15,
@@ -450,10 +452,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[000/110] ..................................................\n",
-      "[050/110] ..................................................\n",
-      "[100/110] ..........\n",
-      "Wall time: 30.8 s\n"
+      "[000/111] ..................................................\n",
+      "[050/111] ..................................................\n",
+      "[100/111] ...........\n",
+      "Wall time: 35.7 s\n"
      ]
     }
    ],
@@ -471,13 +473,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1879-119364.xml\n"
+      "1879-119364.xml.gz\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'Tue Oct 30 16:19:01 2018'"
+       "'Wed Mar 06 14:38:20 2019'"
       ]
      },
      "execution_count": 17,
@@ -536,7 +538,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('number of files before clean: ', 110)\n",
+      "('number of files before clean: ', 111)\n",
       "('number of files after clean: ', 0)\n"
      ]
     }
@@ -573,15 +575,6 @@
     "# check existence of the cache directory:\n",
     "print(os.path.exists(os.path.join(cachedir, 'boring')))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/pydov/__init__.py
+++ b/pydov/__init__.py
@@ -5,7 +5,7 @@ from pydov.util.hooks import SimpleStatusHook
 __author__ = """DOV-Vlaanderen"""
 __version__ = '0.1.0'
 
-cache = pydov.util.caching.TransparentCache()
+cache = pydov.util.caching.PlainTextFileCache()
 
 hooks = [
     SimpleStatusHook(),

--- a/pydov/__init__.py
+++ b/pydov/__init__.py
@@ -5,7 +5,7 @@ from pydov.util.hooks import SimpleStatusHook
 __author__ = """DOV-Vlaanderen"""
 __version__ = '0.1.0'
 
-cache = pydov.util.caching.PlainTextFileCache()
+cache = pydov.util.caching.GzipTextFileCache()
 
 hooks = [
     SimpleStatusHook(),

--- a/pydov/util/caching.py
+++ b/pydov/util/caching.py
@@ -297,8 +297,8 @@ class AbstractFileCache(AbstractCache):
             shutil.rmtree(self.cachedir)
 
 
-class TransparentCache(AbstractFileCache):
-    """Class for transparent caching of downloaded XML files from DOV."""
+class PlainTextFileCache(AbstractFileCache):
+    """Class for plain text caching of downloaded XML files from DOV."""
 
     def _get_filepath(self, datatype, key):
         """Get the location on disk where the object with given datatype and

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -37,7 +37,7 @@ from tests.test_search_itp_lithologischebeschrijvingen import (
 location_dov_xml = 'tests/data/encoding/invalidcharacters.xml'
 
 from tests.test_util_caching import (
-    cache,
+    plaintext_cache,
     nocache,
 )
 
@@ -70,9 +70,10 @@ class TestEncoding(object):
 
     @pytest.mark.online
     @pytest.mark.skipif(not service_ok(), reason="DOV service is unreachable")
-    @pytest.mark.parametrize('cache', [[datetime.timedelta(minutes=15)]],
-                             indirect=['cache'])
-    def test_search_cache(self, cache):
+    @pytest.mark.parametrize('plaintext_cache',
+                             [[datetime.timedelta(minutes=15)]],
+                             indirect=['plaintext_cache'])
+    def test_search_cache(self, plaintext_cache):
         """Test the search method with strange character in the output.
 
         Test whether the output has the correct encoding, both with and
@@ -80,7 +81,8 @@ class TestEncoding(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+        plaintext_cache : pytest.fixture providing
+                pydov.util.caching.PlainTextFileCache
             PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
 
@@ -97,7 +99,7 @@ class TestEncoding(object):
         assert df.uitvoerder[0] == u'Societé Belge des Bétons'
 
         assert os.path.exists(os.path.join(
-            cache.cachedir, 'boring', '1928-031159.xml'))
+            plaintext_cache.cachedir, 'boring', '1928-031159.xml'))
 
         df = boringsearch.search(query=query,
                                  return_fields=('pkey_boring', 'uitvoerder',
@@ -107,27 +109,30 @@ class TestEncoding(object):
 
     @pytest.mark.online
     @pytest.mark.skipif(not service_ok(), reason="DOV service is unreachable")
-    @pytest.mark.parametrize('cache', [[datetime.timedelta(minutes=15)]],
-                             indirect=['cache'])
-    def test_caching(self, cache):
+    @pytest.mark.parametrize('plaintext_cache',
+                             [[datetime.timedelta(minutes=15)]],
+                             indirect=['plaintext_cache'])
+    def test_caching(self, plaintext_cache):
         """Test the caching of an XML containing strange characters.
 
         Test whether the data is saved in the cache.
 
         Parameters
         ----------
-        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+        plaintext_cache : pytest.fixture providing
+                pydov.util.caching.PlainTextFileCache
             PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
 
         """
         cached_file = os.path.join(
-            cache.cachedir, 'boring', '1995-056089.xml')
+            plaintext_cache.cachedir, 'boring', '1995-056089.xml')
 
-        cache.clean()
+        plaintext_cache.clean()
         assert not os.path.exists(cached_file)
 
-        cache.get('https://www.dov.vlaanderen.be/data/boring/1995-056089.xml')
+        plaintext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/1995-056089.xml')
         assert os.path.exists(cached_file)
 
         with open(cached_file, 'r', encoding='utf-8') as cf:
@@ -137,15 +142,17 @@ class TestEncoding(object):
         first_download_time = os.path.getmtime(cached_file)
 
         time.sleep(0.5)
-        cache.get('https://www.dov.vlaanderen.be/data/boring/1995-056089.xml')
+        plaintext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/1995-056089.xml')
         # assure we didn't redownload the file:
         assert os.path.getmtime(cached_file) == first_download_time
 
     @pytest.mark.online
     @pytest.mark.skipif(not service_ok(), reason="DOV service is unreachable")
-    @pytest.mark.parametrize('cache', [[datetime.timedelta(minutes=15)]],
-                             indirect=['cache'])
-    def test_save_content(self, cache):
+    @pytest.mark.parametrize('plaintext_cache',
+                             [[datetime.timedelta(minutes=15)]],
+                             indirect=['plaintext_cache'])
+    def test_save_content(self, plaintext_cache):
         """Test the caching of an XML containing strange characters.
 
         Test if the contents of the saved document are the same as the
@@ -153,18 +160,19 @@ class TestEncoding(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+        plaintext_cache : pytest.fixture providing
+                pydov.util.caching.PlainTextFileCache
             PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
 
         """
         cached_file = os.path.join(
-            cache.cachedir, 'boring', '1995-056089.xml')
+            plaintext_cache.cachedir, 'boring', '1995-056089.xml')
 
-        cache.remove()
+        plaintext_cache.remove()
         assert not os.path.exists(cached_file)
 
-        ref_data = cache.get(
+        ref_data = plaintext_cache.get(
             'https://www.dov.vlaanderen.be/data/boring/1995-056089.xml')
         assert os.path.exists(cached_file)
 
@@ -175,9 +183,10 @@ class TestEncoding(object):
 
     @pytest.mark.online
     @pytest.mark.skipif(not service_ok(), reason="DOV service is unreachable")
-    @pytest.mark.parametrize('cache', [[datetime.timedelta(minutes=15)]],
-                             indirect=['cache'])
-    def test_reuse_content(self, cache):
+    @pytest.mark.parametrize('plaintext_cache',
+                             [[datetime.timedelta(minutes=15)]],
+                             indirect=['plaintext_cache'])
+    def test_reuse_content(self, plaintext_cache):
         """Test the caching of an XML containing strange characters.
 
         Test if the contents returned by the cache are the same as the
@@ -185,22 +194,23 @@ class TestEncoding(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+        plaintext_cache : pytest.fixture providing
+                pydov.util.caching.PlainTextFileCache
             PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
 
         """
         cached_file = os.path.join(
-            cache.cachedir, 'boring', '1995-056089.xml')
+            plaintext_cache.cachedir, 'boring', '1995-056089.xml')
 
-        cache.remove()
+        plaintext_cache.remove()
         assert not os.path.exists(cached_file)
 
-        ref_data = cache.get(
+        ref_data = plaintext_cache.get(
             'https://www.dov.vlaanderen.be/data/boring/1995-056089.xml')
         assert os.path.exists(cached_file)
 
-        cached_data = cache.get(
+        cached_data = plaintext_cache.get(
             'https://www.dov.vlaanderen.be/data/boring/1995-056089.xml')
 
         assert cached_data == ref_data

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -80,8 +80,8 @@ class TestEncoding(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing  pydov.util.caching.TransparentCache
-            TransparentCache using a temporary directory and a maximum age
+        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+            PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
 
         """
@@ -116,8 +116,8 @@ class TestEncoding(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing  pydov.util.caching.TransparentCache
-            TransparentCache using a temporary directory and a maximum age
+        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+            PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
 
         """
@@ -153,8 +153,8 @@ class TestEncoding(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing  pydov.util.caching.TransparentCache
-            TransparentCache using a temporary directory and a maximum age
+        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+            PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
 
         """
@@ -185,8 +185,8 @@ class TestEncoding(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing  pydov.util.caching.TransparentCache
-            TransparentCache using a temporary directory and a maximum age
+        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+            PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
 
         """

--- a/tests/test_util_caching.py
+++ b/tests/test_util_caching.py
@@ -30,12 +30,12 @@ def mp_remote_xml(monkeypatch):
                 data = data.encode('utf-8')
         return data
 
-    monkeypatch.setattr(pydov.util.caching.PlainTextFileCache,
+    monkeypatch.setattr(pydov.util.caching.AbstractFileCache,
                         '_get_remote', _get_remote_data)
 
 
 @pytest.fixture
-def cache(request):
+def plaintext_cache(request):
     """Fixture for a temporary cache.
 
     This fixture should be parametrized, with a list of parameters in the
@@ -78,8 +78,9 @@ class TestPlainTextFileCacheCache(object):
     """Class grouping tests for the pydov.util.caching.PlainTextFileCache
     class."""
 
-    @pytest.mark.parametrize('cache', [[]], indirect=['cache'])
-    def test_clean(self, cache, mp_remote_xml):
+    @pytest.mark.parametrize('plaintext_cache', [[]],
+                             indirect=['plaintext_cache'])
+    def test_clean(self, plaintext_cache, mp_remote_xml):
         """Test the clean method.
 
         Test whether the cached file and the cache directory are nonexistent
@@ -87,7 +88,8 @@ class TestPlainTextFileCacheCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+        plaintext_cache : pytest.fixture providing
+                pydov.util.caching.PlainTextFileCache
             PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
@@ -96,22 +98,24 @@ class TestPlainTextFileCacheCache(object):
 
         """
         cached_file = os.path.join(
-            cache.cachedir, 'boring', '2004-103984.xml')
+            plaintext_cache.cachedir, 'boring', '2004-103984.xml')
 
-        cache.get('https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        plaintext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
         assert os.path.exists(cached_file)
 
-        cache.clean()
+        plaintext_cache.clean()
         assert os.path.exists(cached_file)
-        assert os.path.exists(cache.cachedir)
+        assert os.path.exists(plaintext_cache.cachedir)
 
         time.sleep(1.5)
-        cache.clean()
+        plaintext_cache.clean()
         assert not os.path.exists(cached_file)
-        assert os.path.exists(cache.cachedir)
+        assert os.path.exists(plaintext_cache.cachedir)
 
-    @pytest.mark.parametrize('cache', [[]], indirect=['cache'])
-    def test_remove(self, cache, mp_remote_xml):
+    @pytest.mark.parametrize('plaintext_cache', [[]],
+                             indirect=['plaintext_cache'])
+    def test_remove(self, plaintext_cache, mp_remote_xml):
         """Test the remove method.
 
         Test whether the cache directory is nonexistent after the remove
@@ -119,7 +123,8 @@ class TestPlainTextFileCacheCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+        plaintext_cache : pytest.fixture providing
+                pydov.util.caching.PlainTextFileCache
             PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
@@ -128,24 +133,27 @@ class TestPlainTextFileCacheCache(object):
 
         """
         cached_file = os.path.join(
-            cache.cachedir, 'boring', '2004-103984.xml')
+            plaintext_cache.cachedir, 'boring', '2004-103984.xml')
 
-        cache.get('https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        plaintext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
         assert os.path.exists(cached_file)
 
-        cache.remove()
+        plaintext_cache.remove()
         assert not os.path.exists(cached_file)
-        assert not os.path.exists(cache.cachedir)
+        assert not os.path.exists(plaintext_cache.cachedir)
 
-    @pytest.mark.parametrize('cache', [[]], indirect=['cache'])
-    def test_get_save(self, cache, mp_remote_xml):
+    @pytest.mark.parametrize('plaintext_cache', [[]],
+                             indirect=['plaintext_cache'])
+    def test_get_save(self, plaintext_cache, mp_remote_xml):
         """Test the get method.
 
         Test whether the document is saved in the cache.
 
         Parameters
         ----------
-        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+        plaintext_cache : pytest.fixture providing
+                pydov.util.caching.PlainTextFileCache
             PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
@@ -154,16 +162,18 @@ class TestPlainTextFileCacheCache(object):
 
         """
         cached_file = os.path.join(
-            cache.cachedir, 'boring', '2004-103984.xml')
+            plaintext_cache.cachedir, 'boring', '2004-103984.xml')
 
-        cache.clean()
+        plaintext_cache.clean()
         assert not os.path.exists(cached_file)
 
-        cache.get('https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        plaintext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
         assert os.path.exists(cached_file)
 
-    @pytest.mark.parametrize('cache', [[]], indirect=['cache'])
-    def test_get_reuse(self, cache, mp_remote_xml):
+    @pytest.mark.parametrize('plaintext_cache', [[]],
+                             indirect=['plaintext_cache'])
+    def test_get_reuse(self, plaintext_cache, mp_remote_xml):
         """Test the get method.
 
         Test whether the document is saved in the cache and reused in a
@@ -171,7 +181,8 @@ class TestPlainTextFileCacheCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+        plaintext_cache : pytest.fixture providing
+                pydov.util.caching.PlainTextFileCache
             PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
@@ -180,23 +191,26 @@ class TestPlainTextFileCacheCache(object):
 
         """
         cached_file = os.path.join(
-            cache.cachedir, 'boring', '2004-103984.xml')
+            plaintext_cache.cachedir, 'boring', '2004-103984.xml')
 
-        cache.clean()
+        plaintext_cache.clean()
         assert not os.path.exists(cached_file)
 
-        cache.get('https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        plaintext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
         assert os.path.exists(cached_file)
 
         first_download_time = os.path.getmtime(cached_file)
 
         time.sleep(0.5)
-        cache.get('https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        plaintext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
         # assure we didn't redownload the file:
         assert os.path.getmtime(cached_file) == first_download_time
 
-    @pytest.mark.parametrize('cache', [[]], indirect=['cache'])
-    def test_get_invalid(self, cache, mp_remote_xml):
+    @pytest.mark.parametrize('plaintext_cache', [[]],
+                             indirect=['plaintext_cache'])
+    def test_get_invalid(self, plaintext_cache, mp_remote_xml):
         """Test the get method.
 
         Test whether the document is saved in the cache not reused if the
@@ -204,7 +218,8 @@ class TestPlainTextFileCacheCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+        plaintext_cache : pytest.fixture providing
+                pydov.util.caching.PlainTextFileCache
             PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
@@ -213,23 +228,26 @@ class TestPlainTextFileCacheCache(object):
 
         """
         cached_file = os.path.join(
-            cache.cachedir, 'boring', '2004-103984.xml')
+            plaintext_cache.cachedir, 'boring', '2004-103984.xml')
 
-        cache.clean()
+        plaintext_cache.clean()
         assert not os.path.exists(cached_file)
 
-        cache.get('https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        plaintext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
         assert os.path.exists(cached_file)
 
         first_download_time = os.path.getmtime(cached_file)
 
         time.sleep(1.5)
-        cache.get('https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        plaintext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
         # assure we did redownload the file, since original is invalid now:
         assert os.path.getmtime(cached_file) > first_download_time
 
-    @pytest.mark.parametrize('cache', [[]], indirect=['cache'])
-    def test_save_content(self, cache, mp_remote_xml):
+    @pytest.mark.parametrize('plaintext_cache', [[]],
+                             indirect=['plaintext_cache'])
+    def test_save_content(self, plaintext_cache, mp_remote_xml):
         """Test whether the data is saved in the cache.
 
         Test if the contents of the saved document are the same as the
@@ -237,7 +255,8 @@ class TestPlainTextFileCacheCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+        plaintext_cache : pytest.fixture providing
+                pydov.util.caching.PlainTextFileCache
             PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
@@ -246,12 +265,13 @@ class TestPlainTextFileCacheCache(object):
 
         """
         cached_file = os.path.join(
-            cache.cachedir, 'boring', '2004-103984.xml')
+            plaintext_cache.cachedir, 'boring', '2004-103984.xml')
 
-        cache.clean()
+        plaintext_cache.clean()
         assert not os.path.exists(cached_file)
 
-        cache.get('https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        plaintext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
         assert os.path.exists(cached_file)
 
         with open('tests/data/types/boring/boring.xml', 'r',
@@ -263,8 +283,9 @@ class TestPlainTextFileCacheCache(object):
 
         assert cached_data == ref_data
 
-    @pytest.mark.parametrize('cache', [[]], indirect=['cache'])
-    def test_reuse_content(self, cache, mp_remote_xml):
+    @pytest.mark.parametrize('plaintext_cache', [[]],
+                             indirect=['plaintext_cache'])
+    def test_reuse_content(self, plaintext_cache, mp_remote_xml):
         """Test whether the saved data is reused.
 
         Test if the contents returned by the cache are the same as the
@@ -272,7 +293,8 @@ class TestPlainTextFileCacheCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+        plaintext_cache : pytest.fixture providing
+                pydov.util.caching.PlainTextFileCache
             PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
@@ -281,24 +303,26 @@ class TestPlainTextFileCacheCache(object):
 
         """
         cached_file = os.path.join(
-            cache.cachedir, 'boring', '2004-103984.xml')
+            plaintext_cache.cachedir, 'boring', '2004-103984.xml')
 
-        cache.clean()
+        plaintext_cache.clean()
         assert not os.path.exists(cached_file)
 
-        cache.get('https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        plaintext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
         assert os.path.exists(cached_file)
 
         with open('tests/data/types/boring/boring.xml', 'r') as ref:
             ref_data = ref.read().encode('utf-8')
 
-        cached_data = cache.get(
+        cached_data = plaintext_cache.get(
             'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
 
         assert cached_data == ref_data
 
-    @pytest.mark.parametrize('cache', [[]], indirect=['cache'])
-    def test_return_type(self, cache, mp_remote_xml):
+    @pytest.mark.parametrize('plaintext_cache', [[]],
+                             indirect=['plaintext_cache'])
+    def test_return_type(self, plaintext_cache, mp_remote_xml):
         """The the return type of the get method.
 
         Test wether the get method returns the data in the same datatype (
@@ -306,7 +330,8 @@ class TestPlainTextFileCacheCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+        plaintext_cache : pytest.fixture providing
+                pydov.util.caching.PlainTextFileCache
             PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
@@ -315,17 +340,17 @@ class TestPlainTextFileCacheCache(object):
 
         """
         cached_file = os.path.join(
-            cache.cachedir, 'boring', '2004-103984.xml')
+            plaintext_cache.cachedir, 'boring', '2004-103984.xml')
 
-        cache.clean()
+        plaintext_cache.clean()
         assert not os.path.exists(cached_file)
 
-        ref_data = cache.get(
+        ref_data = plaintext_cache.get(
             'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
         assert type(ref_data) is bytes
 
         assert os.path.exists(cached_file)
 
-        cached_data = cache.get(
+        cached_data = plaintext_cache.get(
             'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
         assert type(cached_data) is bytes

--- a/tests/test_util_caching.py
+++ b/tests/test_util_caching.py
@@ -1,5 +1,6 @@
 """Module grouping tests for the pydov.util.caching module."""
 import datetime
+import gzip
 import os
 import tempfile
 from io import open
@@ -9,7 +10,10 @@ import time
 import pytest
 
 import pydov
-from pydov.util.caching import PlainTextFileCache
+from pydov.util.caching import (
+    PlainTextFileCache,
+    GzipTextFileCache,
+)
 
 
 @pytest.fixture
@@ -62,6 +66,37 @@ def plaintext_cache(request):
     yield plaintext_cache
 
     plaintext_cache.remove()
+    pydov.cache = orig_cache
+
+
+@pytest.fixture
+def gziptext_cache(request):
+    """Fixture for a temporary cache.
+
+    This fixture should be parametrized, with a list of parameters in the
+    order described below.
+
+    Paramaters
+    ----------
+    max_age : datetime.timedelta
+        The maximum age to use for the cache.
+
+    """
+    orig_cache = pydov.cache
+
+    if len(request.param) == 0:
+        max_age = datetime.timedelta(seconds=1)
+    else:
+        max_age = request.param[0]
+
+    gziptext_cache = GzipTextFileCache(
+        cachedir=os.path.join(tempfile.gettempdir(), 'pydov_tests'),
+        max_age=max_age)
+    pydov.cache = gziptext_cache
+
+    yield gziptext_cache
+
+    gziptext_cache.remove()
     pydov.cache = orig_cache
 
 
@@ -352,5 +387,287 @@ class TestPlainTextFileCacheCache(object):
         assert os.path.exists(cached_file)
 
         cached_data = plaintext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        assert type(cached_data) is bytes
+
+
+class TestGzipTextFileCacheCache(object):
+    """Class grouping tests for the pydov.util.caching.PlainTextFileCache
+    class."""
+
+    @pytest.mark.parametrize('gziptext_cache', [[]],
+                             indirect=['gziptext_cache'])
+    def test_clean(self, gziptext_cache, mp_remote_xml):
+        """Test the clean method.
+
+        Test whether the cached file and the cache directory are nonexistent
+        after the clean method has been called.
+
+        Parameters
+        ----------
+        gziptext_cache : pytest.fixture providing
+                pydov.util.caching.GzipTextFileCache
+            GzipTextFileCache using a temporary directory and a maximum age
+            of 1 second.
+        mp_remote_xml : pytest.fixture
+            Monkeypatch the call to the remote DOV service returning an XML
+            document.
+
+        """
+        cached_file = os.path.join(
+            gziptext_cache.cachedir, 'boring', '2004-103984.xml.gz')
+
+        gziptext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        assert os.path.exists(cached_file)
+
+        gziptext_cache.clean()
+        assert os.path.exists(cached_file)
+        assert os.path.exists(gziptext_cache.cachedir)
+
+        time.sleep(1.5)
+        gziptext_cache.clean()
+        assert not os.path.exists(cached_file)
+        assert os.path.exists(gziptext_cache.cachedir)
+
+    @pytest.mark.parametrize('gziptext_cache', [[]],
+                             indirect=['gziptext_cache'])
+    def test_remove(self, gziptext_cache, mp_remote_xml):
+        """Test the remove method.
+
+        Test whether the cache directory is nonexistent after the remove
+        method has been called.
+
+        Parameters
+        ----------
+        gziptext_cache : pytest.fixture providing
+                pydov.util.caching.GzipTextFileCache
+            GzipTextFileCache using a temporary directory and a maximum age
+            of 1 second.
+        mp_remote_xml : pytest.fixture
+            Monkeypatch the call to the remote DOV service returning an XML
+            document.
+
+        """
+        cached_file = os.path.join(
+            gziptext_cache.cachedir, 'boring', '2004-103984.xml.gz')
+
+        gziptext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        assert os.path.exists(cached_file)
+
+        gziptext_cache.remove()
+        assert not os.path.exists(cached_file)
+        assert not os.path.exists(gziptext_cache.cachedir)
+
+    @pytest.mark.parametrize('gziptext_cache', [[]],
+                             indirect=['gziptext_cache'])
+    def test_get_save(self, gziptext_cache, mp_remote_xml):
+        """Test the get method.
+
+        Test whether the document is saved in the cache.
+
+        Parameters
+        ----------
+        gziptext_cache : pytest.fixture providing
+                pydov.util.caching.GzipTextFileCache
+            GzipTextFileCache using a temporary directory and a maximum age
+            of 1 second.
+        mp_remote_xml : pytest.fixture
+            Monkeypatch the call to the remote DOV service returning an XML
+            document.
+
+        """
+        cached_file = os.path.join(
+            gziptext_cache.cachedir, 'boring', '2004-103984.xml.gz')
+
+        gziptext_cache.clean()
+        assert not os.path.exists(cached_file)
+
+        gziptext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        assert os.path.exists(cached_file)
+
+    @pytest.mark.parametrize('gziptext_cache', [[]],
+                             indirect=['gziptext_cache'])
+    def test_get_reuse(self, gziptext_cache, mp_remote_xml):
+        """Test the get method.
+
+        Test whether the document is saved in the cache and reused in a
+        second function call.
+
+        Parameters
+        ----------
+        gziptext_cache : pytest.fixture providing
+                pydov.util.caching.GzipTextFileCache
+            GzipTextFileCache using a temporary directory and a maximum age
+            of 1 second.
+        mp_remote_xml : pytest.fixture
+            Monkeypatch the call to the remote DOV service returning an XML
+            document.
+
+        """
+        cached_file = os.path.join(
+            gziptext_cache.cachedir, 'boring', '2004-103984.xml.gz')
+
+        gziptext_cache.clean()
+        assert not os.path.exists(cached_file)
+
+        gziptext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        assert os.path.exists(cached_file)
+
+        first_download_time = os.path.getmtime(cached_file)
+
+        time.sleep(0.5)
+        gziptext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        # assure we didn't redownload the file:
+        assert os.path.getmtime(cached_file) == first_download_time
+
+    @pytest.mark.parametrize('gziptext_cache', [[]],
+                             indirect=['gziptext_cache'])
+    def test_get_invalid(self, gziptext_cache, mp_remote_xml):
+        """Test the get method.
+
+        Test whether the document is saved in the cache not reused if the
+        second function call is after the maximum age of the cached file.
+
+        Parameters
+        ----------
+        gziptext_cache : pytest.fixture providing
+                pydov.util.caching.GzipTextFileCache
+            GzipTextFileCache using a temporary directory and a maximum age
+            of 1 second.
+        mp_remote_xml : pytest.fixture
+            Monkeypatch the call to the remote DOV service returning an XML
+            document.
+
+        """
+        cached_file = os.path.join(
+            gziptext_cache.cachedir, 'boring', '2004-103984.xml.gz')
+
+        gziptext_cache.clean()
+        assert not os.path.exists(cached_file)
+
+        gziptext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        assert os.path.exists(cached_file)
+
+        first_download_time = os.path.getmtime(cached_file)
+
+        time.sleep(1.5)
+        gziptext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        # assure we did redownload the file, since original is invalid now:
+        assert os.path.getmtime(cached_file) > first_download_time
+
+    @pytest.mark.parametrize('gziptext_cache', [[]],
+                             indirect=['gziptext_cache'])
+    def test_save_content(self, gziptext_cache, mp_remote_xml):
+        """Test whether the data is saved in the cache.
+
+        Test if the contents of the saved document are the same as the
+        original data.
+
+        Parameters
+        ----------
+        gziptext_cache : pytest.fixture providing
+                pydov.util.caching.GzipTextFileCache
+            GzipTextFileCache using a temporary directory and a maximum age
+            of 1 second.
+        mp_remote_xml : pytest.fixture
+            Monkeypatch the call to the remote DOV service returning an XML
+            document.
+
+        """
+        cached_file = os.path.join(
+            gziptext_cache.cachedir, 'boring', '2004-103984.xml.gz')
+
+        gziptext_cache.clean()
+        assert not os.path.exists(cached_file)
+
+        gziptext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        assert os.path.exists(cached_file)
+
+        with open('tests/data/types/boring/boring.xml', 'r',
+                  encoding='utf-8') as ref:
+            ref_data = ref.read()
+
+        with gzip.open(cached_file, 'rb') as cached:
+            cached_data = cached.read().decode('utf-8')
+
+        assert cached_data == ref_data
+
+    @pytest.mark.parametrize('gziptext_cache', [[]],
+                             indirect=['gziptext_cache'])
+    def test_reuse_content(self, gziptext_cache, mp_remote_xml):
+        """Test whether the saved data is reused.
+
+        Test if the contents returned by the cache are the same as the
+        original data.
+
+        Parameters
+        ----------
+        gziptext_cache : pytest.fixture providing
+                pydov.util.caching.GzipTextFileCache
+            GzipTextFileCache using a temporary directory and a maximum age
+            of 1 second.
+        mp_remote_xml : pytest.fixture
+            Monkeypatch the call to the remote DOV service returning an XML
+            document.
+
+        """
+        cached_file = os.path.join(
+            gziptext_cache.cachedir, 'boring', '2004-103984.xml.gz')
+
+        gziptext_cache.clean()
+        assert not os.path.exists(cached_file)
+
+        gziptext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        assert os.path.exists(cached_file)
+
+        with open('tests/data/types/boring/boring.xml', 'r') as ref:
+            ref_data = ref.read().encode('utf-8')
+
+        cached_data = gziptext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+
+        assert cached_data == ref_data
+
+    @pytest.mark.parametrize('gziptext_cache', [[]],
+                             indirect=['gziptext_cache'])
+    def test_return_type(self, gziptext_cache, mp_remote_xml):
+        """The the return type of the get method.
+
+        Test wether the get method returns the data in the same datatype (
+        i.e. bytes) regardless of the data was cached or not.
+
+        Parameters
+        ----------
+        gziptext_cache : pytest.fixture providing
+                pydov.util.caching.GzipTextFileCache
+            GzipTextFileCache using a temporary directory and a maximum age
+            of 1 second.
+        mp_remote_xml : pytest.fixture
+            Monkeypatch the call to the remote DOV service returning an XML
+            document.
+
+        """
+        cached_file = os.path.join(
+            gziptext_cache.cachedir, 'boring', '2004-103984.xml.gz')
+
+        gziptext_cache.clean()
+        assert not os.path.exists(cached_file)
+
+        ref_data = gziptext_cache.get(
+            'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
+        assert type(ref_data) is bytes
+
+        assert os.path.exists(cached_file)
+
+        cached_data = gziptext_cache.get(
             'https://www.dov.vlaanderen.be/data/boring/2004-103984.xml')
         assert type(cached_data) is bytes

--- a/tests/test_util_caching.py
+++ b/tests/test_util_caching.py
@@ -9,7 +9,7 @@ import time
 import pytest
 
 import pydov
-from pydov.util.caching import TransparentCache
+from pydov.util.caching import PlainTextFileCache
 
 
 @pytest.fixture
@@ -30,7 +30,7 @@ def mp_remote_xml(monkeypatch):
                 data = data.encode('utf-8')
         return data
 
-    monkeypatch.setattr(pydov.util.caching.TransparentCache,
+    monkeypatch.setattr(pydov.util.caching.PlainTextFileCache,
                         '_get_remote', _get_remote_data)
 
 
@@ -54,14 +54,14 @@ def cache(request):
     else:
         max_age = request.param[0]
 
-    transparent_cache = TransparentCache(
+    plaintext_cache = PlainTextFileCache(
         cachedir=os.path.join(tempfile.gettempdir(), 'pydov_tests'),
         max_age=max_age)
-    pydov.cache = transparent_cache
+    pydov.cache = plaintext_cache
 
-    yield transparent_cache
+    yield plaintext_cache
 
-    transparent_cache.remove()
+    plaintext_cache.remove()
     pydov.cache = orig_cache
 
 
@@ -74,8 +74,8 @@ def nocache():
     pydov.cache = orig_cache
 
 
-class TestTransparentCache(object):
-    """Class grouping tests for the pydov.util.caching.TransparentCache
+class TestPlainTextFileCacheCache(object):
+    """Class grouping tests for the pydov.util.caching.PlainTextFileCache
     class."""
 
     @pytest.mark.parametrize('cache', [[]], indirect=['cache'])
@@ -87,8 +87,8 @@ class TestTransparentCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing  pydov.util.caching.TransparentCache
-            TransparentCache using a temporary directory and a maximum age
+        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+            PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
             Monkeypatch the call to the remote DOV service returning an XML
@@ -119,8 +119,8 @@ class TestTransparentCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing  pydov.util.caching.TransparentCache
-            TransparentCache using a temporary directory and a maximum age
+        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+            PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
             Monkeypatch the call to the remote DOV service returning an XML
@@ -145,8 +145,8 @@ class TestTransparentCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing  pydov.util.caching.TransparentCache
-            TransparentCache using a temporary directory and a maximum age
+        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+            PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
             Monkeypatch the call to the remote DOV service returning an XML
@@ -171,8 +171,8 @@ class TestTransparentCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing  pydov.util.caching.TransparentCache
-            TransparentCache using a temporary directory and a maximum age
+        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+            PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
             Monkeypatch the call to the remote DOV service returning an XML
@@ -204,8 +204,8 @@ class TestTransparentCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing  pydov.util.caching.TransparentCache
-            TransparentCache using a temporary directory and a maximum age
+        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+            PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
             Monkeypatch the call to the remote DOV service returning an XML
@@ -237,8 +237,8 @@ class TestTransparentCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing  pydov.util.caching.TransparentCache
-            TransparentCache using a temporary directory and a maximum age
+        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+            PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
             Monkeypatch the call to the remote DOV service returning an XML
@@ -272,8 +272,8 @@ class TestTransparentCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing  pydov.util.caching.TransparentCache
-            TransparentCache using a temporary directory and a maximum age
+        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+            PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
             Monkeypatch the call to the remote DOV service returning an XML
@@ -306,8 +306,8 @@ class TestTransparentCache(object):
 
         Parameters
         ----------
-        cache : pytest.fixture providing  pydov.util.caching.TransparentCache
-            TransparentCache using a temporary directory and a maximum age
+        cache : pytest.fixture providing pydov.util.caching.PlainTextFileCache
+            PlainTextFileCache using a temporary directory and a maximum age
             of 1 second.
         mp_remote_xml : pytest.fixture
             Monkeypatch the call to the remote DOV service returning an XML

--- a/tests/test_util_hooks.py
+++ b/tests/test_util_hooks.py
@@ -11,7 +11,7 @@ from pydov.util.hooks import (
 from tests.abstract import service_ok
 
 from tests.test_util_caching import (
-    cache,
+    plaintext_cache,
     nocache,
 )
 
@@ -174,9 +174,10 @@ class TestHooks(object):
 
     @pytest.mark.online
     @pytest.mark.skipif(not service_ok(), reason="DOV service is unreachable")
-    @pytest.mark.parametrize('cache', [[datetime.timedelta(minutes=15)]],
-                             indirect=['cache'])
-    def test_wfs_and_xml_cache(self, temp_hooks, cache):
+    @pytest.mark.parametrize('plaintext_cache',
+                             [[datetime.timedelta(minutes=15)]],
+                             indirect=['plaintext_cache'])
+    def test_wfs_and_xml_cache(self, temp_hooks, plaintext_cache):
         """Test the search method providing both a location and a query.
 
         Test whether a dataframe is returned.
@@ -190,7 +191,7 @@ class TestHooks(object):
             Monkeypatch the call to get WFS features.
         temp_hooks : pytest.fixture
             Fixture removing default hooks and installing HookCounter.
-        cache : pytest.fixture
+        plaintext_cache : pytest.fixture
             Fixture temporarily setting up a testcache with max_age of 1
             second.
 


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Introduce GzipTextFileCache that uses GZIP to compress cached XML documents. These take up to 1/10th the size of plain text documents.

The old implementation using plain text is still available as PlainTextFileCache.

Introduce AbstractCache for anyone wanting to implement their own caching system.

Closes #131 
