### PR TITLE
Appveyor: install owslib (and pyproj) with conda.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: conda.exe update -y -q conda
     - cmd: conda.exe config --add channels conda-forge
-    - cmd: conda.exe install -y -q numpy pandas
+    - cmd: conda.exe install -y -q numpy pandas pyproj
     - cmd: call %CONDA_INSTALL_LOCN%\python.exe -m pip install --ignore-installed --no-cache-dir -r requirements_appveyor.txt
     - ps: if($env:PY_INSTALL) { & ($env:CONDA_INSTALL_LOCN + "\Scripts\conda.exe") install -y -q $env:PY_INSTALL }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: conda.exe update -y -q conda
     - cmd: conda.exe config --add channels conda-forge
-    - cmd: conda.exe install -y -q numpy pandas pyproj
+    - cmd: conda.exe install -y -q numpy pandas owslib
     - cmd: call %CONDA_INSTALL_LOCN%\python.exe -m pip install --ignore-installed --no-cache-dir -r requirements_appveyor.txt
     - ps: if($env:PY_INSTALL) { & ($env:CONDA_INSTALL_LOCN + "\Scripts\conda.exe") install -y -q $env:PY_INSTALL }
 

--- a/requirements_appveyor.txt
+++ b/requirements_appveyor.txt
@@ -1,4 +1,3 @@
-owslib
 requests
 pip
 bumpversion


### PR DESCRIPTION
Install owslib (and as a consequence: pyproj) with conda instead of pip to avoid compilation error.

Closes #157 
