### PR TITLE
Add support to Join with a dataframe containing a single element too

### DIFF
--- a/pydov/util/query.py
+++ b/pydov/util/query.py
@@ -33,14 +33,14 @@ class PropertyInList(object):
         Raises
         ------
         ValueError
-            If the given list does not contain at least two distinct items.
+            If the given list does not contain at least a single item.
 
         """
         if not isinstance(lst, list) and not isinstance(lst, set):
             raise ValueError('list should be of type "list" or "set"')
 
         if len(set(lst)) < 1:
-            raise ValueError('list should contains at least a single item')
+            raise ValueError('list should contain at least a single item')
         elif len(set(lst)) == 1:
             self.query = PropertyIsEqualTo(propertyname, set(lst).pop())
         else:
@@ -94,9 +94,8 @@ class Join(PropertyInList):
             If `using` is None and the `on` column is not present in the
             dataframe.
 
-            If the dataframe does not contain at least two different values
-            in the `using` column. A Join is probably overkill here,
-            use PropertyIsEqualTo instead.
+            If the dataframe does not contain at least a single non-null value
+            in the `using` column.
 
         """
         if using is None:

--- a/pydov/util/query.py
+++ b/pydov/util/query.py
@@ -7,7 +7,7 @@ from owslib.fes import (
 )
 
 
-class PropertyInList(Or):
+class PropertyInList(object):
     """Filter expression to test whether a given property has one of the
     values from a list.
 
@@ -39,13 +39,24 @@ class PropertyInList(Or):
         if not isinstance(lst, list) and not isinstance(lst, set):
             raise ValueError('list should be of type "list" or "set"')
 
-        if len(set(lst)) < 2:
-            raise ValueError('list should contain at least two different '
-                             'elements.')
+        if len(set(lst)) < 1:
+            raise ValueError('list should contains at least a single item')
+        elif len(set(lst)) == 1:
+            self.query = PropertyIsEqualTo(propertyname, set(lst).pop())
+        else:
+            self.query = Or(
+                [PropertyIsEqualTo(propertyname, i) for i in set(lst)])
 
-        super(PropertyInList, self).__init__(
-            [PropertyIsEqualTo(propertyname, i) for i in set(lst)]
-        )
+    def toXML(self):
+        """Return the XML representation of the PropertyInList query.
+
+        Returns
+        -------
+        xml : etree.ElementTree
+            XML representation of the PropertyInList
+
+        """
+        return self.query.toXML()
 
 
 class Join(PropertyInList):
@@ -98,8 +109,8 @@ class Join(PropertyInList):
 
         value_list = list(dataframe[using].dropna().unique())
 
-        if len(set(value_list)) < 2:
-            raise ValueError("dataframe should contain at least two "
-                             "different values in column '{}'.".format(using))
+        if len(set(value_list)) < 1:
+            raise ValueError("dataframe should contain at least a single "
+                             "value in column '{}'.".format(using))
 
         super(Join, self).__init__(on, value_list)

--- a/tests/test_util_query.py
+++ b/tests/test_util_query.py
@@ -74,9 +74,21 @@ class TestPropertyInList(object):
         Test whether a ValueError is raised.
 
         """
-        with pytest.raises(ValueError):
-            l = ['a']
-            PropertyInList('methode', l)
+        l = ['a']
+
+        query = PropertyInList('methode', l)
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/ogc}PropertyIsEqualTo'
+
+        propertyname = xml.find('./{http://www.opengis.net/ogc}PropertyName')
+        assert propertyname.text == 'methode'
+
+        literal = xml.find('./{http://www.opengis.net/ogc}Literal')
+        assert literal.text in l
+
+        l.remove(literal.text)
+        assert len(l) == 0
 
     def test_tooshort_duplicate(self):
         """Test the PropertyInList expression with a list containing
@@ -85,9 +97,22 @@ class TestPropertyInList(object):
         Test whether a ValueError is raised.
 
         """
-        with pytest.raises(ValueError):
-            l = ['a', 'a']
-            PropertyInList('methode', l)
+        l = ['a', 'a']
+        l_output = ['a']
+
+        query = PropertyInList('methode', l)
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/ogc}PropertyIsEqualTo'
+
+        propertyname = xml.find('./{http://www.opengis.net/ogc}PropertyName')
+        assert propertyname.text == 'methode'
+
+        literal = xml.find('./{http://www.opengis.net/ogc}Literal')
+        assert literal.text in l_output
+
+        l_output.remove(literal.text)
+        assert len(l_output) == 0
 
     def test_nolist(self):
         """Test the PropertyInList expression with a string instead of a list.
@@ -200,15 +225,26 @@ class TestJoin(object):
         Test whether a ValueError is raised.
 
         """
-        with pytest.raises(ValueError):
-            l = ['https://www.dov.vlaanderen.be/data/boring/1986-068853']
+        l = ['https://www.dov.vlaanderen.be/data/boring/1986-068853']
 
-            df = pd.DataFrame({
-                'pkey_boring': pd.Series(l),
-                'diepte_tot_m': pd.Series([10])
-            })
+        df = pd.DataFrame({
+            'pkey_boring': pd.Series(l),
+            'diepte_tot_m': pd.Series([10])
+        })
 
-            Join(df, 'pkey_boring')
+        query = Join(df, 'pkey_boring')
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/ogc}PropertyIsEqualTo'
+
+        propertyname = xml.find('./{http://www.opengis.net/ogc}PropertyName')
+        assert propertyname.text == 'pkey_boring'
+
+        literal = xml.find('./{http://www.opengis.net/ogc}Literal')
+        assert literal.text in l
+
+        l.remove(literal.text)
+        assert len(l) == 0
 
     def test_tooshort_duplicate(self):
         """Test the Join expression with a dataframe containing two
@@ -217,16 +253,28 @@ class TestJoin(object):
         Test whether a ValueError is raised.
 
         """
-        with pytest.raises(ValueError):
-            l = ['https://www.dov.vlaanderen.be/data/boring/1986-068853',
-                 'https://www.dov.vlaanderen.be/data/boring/1986-068853']
+        l = ['https://www.dov.vlaanderen.be/data/boring/1986-068853',
+             'https://www.dov.vlaanderen.be/data/boring/1986-068853']
+        l_output = ['https://www.dov.vlaanderen.be/data/boring/1986-068853']
 
-            df = pd.DataFrame({
-                'pkey_boring': pd.Series(l),
-                'diepte_tot_m': pd.Series([10, 20])
-            })
+        df = pd.DataFrame({
+            'pkey_boring': pd.Series(l),
+            'diepte_tot_m': pd.Series([10, 20])
+        })
 
-            Join(df, 'pkey_boring')
+        query = Join(df, 'pkey_boring')
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/ogc}PropertyIsEqualTo'
+
+        propertyname = xml.find('./{http://www.opengis.net/ogc}PropertyName')
+        assert propertyname.text == 'pkey_boring'
+
+        literal = xml.find('./{http://www.opengis.net/ogc}Literal')
+        assert literal.text in l_output
+
+        l_output.remove(literal.text)
+        assert len(l_output) == 0
 
     def test_on(self):
         """Test the Join expression with a standard dataframe and 'on'.

--- a/tests/test_util_query.py
+++ b/tests/test_util_query.py
@@ -1,5 +1,6 @@
 """Module grouping tests for the pydov.util.query module."""
 import pandas as pd
+import numpy as np
 import pytest
 
 from pydov.util.query import (
@@ -67,11 +68,12 @@ class TestPropertyInList(object):
 
         assert len(l_output) == 0
 
-    def test_tooshort(self):
+    def test_list_single(self):
         """Test the PropertyInList expression with a list containing
         a single item.
 
-        Test whether a ValueError is raised.
+        Test whether the generated query is correct and does contain only a
+        single PropertyIsEqualTo.
 
         """
         l = ['a']
@@ -90,11 +92,12 @@ class TestPropertyInList(object):
         l.remove(literal.text)
         assert len(l) == 0
 
-    def test_tooshort_duplicate(self):
+    def test_list_single_duplicate(self):
         """Test the PropertyInList expression with a list containing
-        a two identical items.
+        a single duplicated item.
 
-        Test whether a ValueError is raised.
+        Test whether the generated query is correct and does contain only a
+        single PropertyIsEqualTo.
 
         """
         l = ['a', 'a']
@@ -113,6 +116,16 @@ class TestPropertyInList(object):
 
         l_output.remove(literal.text)
         assert len(l_output) == 0
+
+    def test_emptylist(self):
+        """Test the PropertyInList expression with an empty list.
+
+        Test whether a ValueError is raised.
+
+        """
+        with pytest.raises(ValueError):
+            l = []
+            PropertyInList('methode', l)
 
     def test_nolist(self):
         """Test the PropertyInList expression with a string instead of a list.
@@ -219,10 +232,11 @@ class TestJoin(object):
 
             Join(df, 'pkey_sondering')
 
-    def test_tooshort(self):
+    def test_single(self):
         """Test the Join expression with a dataframe containing a single row.
 
-        Test whether a ValueError is raised.
+        Test whether the generated query is correct and does contain only a
+        single PropertyIsEqualTo.
 
         """
         l = ['https://www.dov.vlaanderen.be/data/boring/1986-068853']
@@ -246,11 +260,12 @@ class TestJoin(object):
         l.remove(literal.text)
         assert len(l) == 0
 
-    def test_tooshort_duplicate(self):
+    def test_single_duplicate(self):
         """Test the Join expression with a dataframe containing two
         identical keys.
 
-        Test whether a ValueError is raised.
+        Test whether the generated query is correct and does contain only a
+        single PropertyIsEqualTo.
 
         """
         l = ['https://www.dov.vlaanderen.be/data/boring/1986-068853',
@@ -275,6 +290,20 @@ class TestJoin(object):
 
         l_output.remove(literal.text)
         assert len(l_output) == 0
+
+    def test_empty(self):
+        """Test the Join expression with an empty dataframe.
+
+        Test whether a ValueError is raised
+
+        """
+        df = pd.DataFrame({
+            'pkey_boring': [np.nan, np.nan],
+            'diepte_tot_m': pd.Series([10, 20])
+        })
+
+        with pytest.raises(ValueError):
+            Join(df, 'pkey_boring')
 
     def test_on(self):
         """Test the Join expression with a standard dataframe and 'on'.


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Support PropertyInList with a single-element list and Join with a dataframe containing a single not-null value in the `using` column.

Closes #206 
