### PR TITLE
Pin requirements to keep Python2 support.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ install:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: conda.exe update -y -q conda
     - cmd: conda.exe config --add channels conda-forge
-    - cmd: conda.exe install -y -q numpy pandas owslib
+    - cmd: conda.exe install -y -q numpy pandas owslib=0.18.0
     - cmd: call %CONDA_INSTALL_LOCN%\python.exe -m pip install --ignore-installed --no-cache-dir -r requirements_appveyor.txt
     - ps: if($env:PY_INSTALL) { & ($env:CONDA_INSTALL_LOCN + "\Scripts\conda.exe") install -y -q $env:PY_INSTALL }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ install:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: conda.exe update -y -q conda
     - cmd: conda.exe config --add channels conda-forge
-    - cmd: conda.exe install -y -q numpy pandas owslib=0.18.0
+    - cmd: conda.exe install -y -q numpy"<1.17.0" pandas"<0.25.0" owslib"<0.19.0"
     - cmd: call %CONDA_INSTALL_LOCN%\python.exe -m pip install --ignore-installed --no-cache-dir -r requirements_appveyor.txt
     - ps: if($env:PY_INSTALL) { & ($env:CONDA_INSTALL_LOCN + "\Scripts\conda.exe") install -y -q $env:PY_INSTALL }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-owslib<=0.18.0
-pandas
-numpy
+owslib<0.19.0
+pandas<0.25.0
+numpy<1.17.0
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-owslib
+owslib<=0.18.0
 pandas
 numpy
 requests


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

OWSLib 0.19.0 (released last week) dropped support for Python2. Since we don't pin versions in the requirements file, pydov's Travis is failing on Python2 now. Same goes for pandas and numpy, who have dropped support for Python2 in their latest releases.

In order to release a final 1.0.0 of pydov which is still Python2 compatible, I suggest pinning:
* owslib<0.19.0
* pandas<0.25.0
* numpy<1.17.0

Closes #215