### PR TITLE
Increase request timeout to 5 minutes.

### DIFF
--- a/pydov/__init__.py
+++ b/pydov/__init__.py
@@ -15,6 +15,6 @@ hooks = [
 
 # Package wide requests session object. This increases performance as using a
 # session object allows connection pooling and TCP connection reuse.
-request_timeout = 60
+request_timeout = 300
 session = requests.Session()
 session.headers.update({'user-agent': 'pydov/{}'.format(pydov.__version__)})


### PR DESCRIPTION
Increase the default request timeout to 5 minutes instead of 1, to align
with the reverse proxy settings serverside.

This allows executing larger WFS queries in pydov.

<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Closes #217 
