### PR TITLE
Make meetnet_code a string.

### DIFF
--- a/docs/output_fields.rst
+++ b/docs/output_fields.rst
@@ -214,7 +214,7 @@ Groundwater screens (grondwaterfilters)
     y,1,float,194090
     start_grondwaterlocatie_mtaw,1,float,NaN
     gemeente,1,string,Destelbergen
-    meetnet_code,10,integer,1
+    meetnet_code,10,string,1
     aquifer_code,10,string,0100
     grondwaterlichaam_code,10,string,CVS_0160_GWL_1
     regime,10,string,freatisch

--- a/pydov/types/grondwaterfilter.py
+++ b/pydov/types/grondwaterfilter.py
@@ -87,7 +87,7 @@ class GrondwaterFilter(AbstractDovType):
         XmlField(name='meetnet_code',
                  source_xpath='/filter/meetnet',
                  definition='Tot welk meetnet behoort deze filter.',
-                 datatype='integer',
+                 datatype='string',
                  xsd_type=XsdType(
                      xsd_schema=_filterDataCodes_xsd,
                      typename='MeetnetEnumType')),

--- a/tests/test_search_grondwaterfilter.py
+++ b/tests/test_search_grondwaterfilter.py
@@ -208,4 +208,4 @@ class TestGrondwaterfilterSearch(AbstractTestSearch):
             return_fields=('pkey_filter', 'gw_id', 'filternummer',
                            'meetnet_code'))
 
-        assert df.meetnet_code[0] == 8
+        assert df.meetnet_code[0] == '8'


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

The meetnet_code XML attribute of the GrondwaterFilter type should be of type 'string' instead of 'integer'.

The next release of the DOV XML schema introduces "meetnet 20 – eDOV erkende boorbedrijven" with code edov.

Closes #219 
