### PR TITLE
Remove pins in the requirements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ install:
     - cmd: conda.exe update -y -q conda
     - cmd: conda.exe config --add channels conda-forge
     - cmd: conda.exe install -y -q python=%CONDA_PY:~0,1%.%CONDA_PY:~1,2%
-    - cmd: conda.exe install -y -q numpy"<1.17.0" pandas"<0.25.0" owslib"<0.19.0"
+    - cmd: conda.exe install -y -q numpy pandas owslib
     - cmd: call %CONDA_INSTALL_LOCN%\python.exe -m pip install --ignore-installed --no-cache-dir -r requirements_appveyor.txt
 
 build: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-owslib<0.19.0
-pandas<0.25.0
-numpy<1.17.0
+owslib
+pandas
+numpy
 requests


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.

Since python 2 support is removed, those pins can be relaxed again I think.