### PR TITLE
Tests: use HEAD instead of GET in service_ok

### DIFF
--- a/tests/abstract.py
+++ b/tests/abstract.py
@@ -14,6 +14,7 @@ from pandas.api.types import (
     is_int64_dtype, is_object_dtype,
     is_bool_dtype, is_float_dtype)
 
+import pydov
 from owslib.fes import (
     PropertyIsEqualTo,
     SortBy,
@@ -51,7 +52,8 @@ def service_ok(timeout=5):
     """
     def check_url(url, timeout):
         try:
-            ok = requests.get(url, timeout=timeout).ok
+            ok = pydov.session.head(
+                url, allow_redirects=True, timeout=timeout).ok
         except requests.exceptions.ReadTimeout:
             ok = False
         except requests.exceptions.ConnectTimeout:


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Since we only rely on the status code and the headers to determine if a
service is working or not, it is not needed to perform a GET (resulting
in downloads of data we don't need).

Instead we could use a HEAD request. Since Requests does not follow
redirects by default when using HEAD [1], we enable it explicitly using
allow_redirects.

Also update to use the global pydov requests session instead of creating
a new one for each call.

[1]: https://2.python-requests.org/en/master/user/quickstart/#redirection-and-history
