### PR TITLE
Refactor and extend hooks system

### DIFF
--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -44,24 +44,71 @@ implementation of the hooks itself.
 Available event hooks
 .....................
 
-wfs_search_init
+meta_received (url: str, response: bytes)
+    This method will be called whenever a response for a metadata request is
+    received. There are two parameters, `url` with the full URL of the metadata
+    request and `response` with the response from the server.
+
+    Metadata requests include, amongst others: WFS GetCapabilities,
+    requests for MD_Metadata, FC_FeatureCatalogue and XSD schemas. These are
+    all calls except for WFS GetFeature requests and XML downloads of DOV data
+    - these are other hooks.
+
+inject_meta_response (url: str) -> bytes
+    This method can be used to inject a custom response for a metadata request
+    with the given URL. There is one parameter `url` with the full URL of the
+    metadata request.
+
+    When at least one registered hook returns a response for a given URL,
+    the remote call is not executed and instead the response from the
+    last registered hook (that is non-null) is used instead.
+
+wfs_search_init (typename: str)
     This method will be called whenever a WFS search is initiated. There is
     one parameter `typename` with the WFS typename that is queried.
 
-wfs_search_result
+wfs_search_result (number_of_results: int)
     This method will be called whenever a WFS search is completed. There is
     one parameter `number_of_results` with the number of search results.
 
-xml_requested
-    This method will be called whenever an XML document is needed. There is
-    one parameter `pkey_object` with the permanent key of the DOV object.
-    This event is either followed by `xml_cache_hit` or `xml_downloaded`.
+wfs_search_result_received (query: etree.ElementTree, features: etree.ElementTree)
+    This method will be called whenever a WFS search finished. There are two
+    parameters, `query` is the WFS GetFeature request sent to the server and
+    `features` is the FeatureCollection received in response.
+
+inject_wfs_getfeature_response (query: etree.ElementTree) -> bytes
+    This method can be used to inject a custom response for a WFS GetFeature
+    request with the given query. There is one parameter `query` with the WFS
+    GetFeature request sent to the server.
+
+    When at least one registered hook returns a response for a given query,
+    the remote call is not executed and instead the response from the
+    last registered hook (that is non-null) is used instead.
+
+xml_received (pkey_object: str, xml: bytes)
+    This method will be called whenever an XML document is received, either
+    from the cache or from the remote DOV service. There are two parameters,
+    `pkey_object` with the permanent key of the DOV object and `xml` containing
+    the full XML representation.
 
     Because of parallel processing, this method will be called simultaneously
     from multiple threads. Make sure your implementation is threadsafe or uses
     locking.
 
-xml_cache_hit
+inject_xml_response (pkey_object: str) -> bytes
+    This method can be used to inject a custom response for a DOV XML
+    request for the given object. There is one parameter `pkey_object` with
+    the permanent key of the DOV object.
+
+    When at least one registered hook returns a response for a given pkey,
+    the remote call is not executed and instead the response from the
+    last registered hook (that is non-null) is used instead.
+
+    Because of parallel processing, this method will be called
+    simultaneously from multiple threads. Make sure your implementation is
+    threadsafe or uses locking.
+
+xml_cache_hit (pkey_object: str)
     This method will be called whenever an XML document is reused from the
     cache. There is one parameter `pkey_object` with the permanent key of
     the DOV object.
@@ -70,7 +117,7 @@ xml_cache_hit
     from multiple threads. Make sure your implementation is threadsafe or uses
     locking.
 
-xml_downloaded
+xml_downloaded (pkey_object: str)
     This method will be called whenever an XML document is downloaded from
     the DOV webservices. There is one parameter `pkey_object` with the
     permanent key of the DOV object.

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -18,7 +18,7 @@ issuing::
 
     import pydov
 
-    pydov.hooks = []
+    pydov.hooks.clear()
 
 
 Writing custom hooks
@@ -27,12 +27,12 @@ Users can write custom hooks and add them to pydov at runtime, to be able to
 interact with pydov at the occurance of certain 'events'.
 
 To implement custom hooks, create a new subclass of
-:class:`pydov.util.hooks.AbstractHook`. An instance of this class can then by
-registered as a pydov hook, and implemented methods will be subsequently be
-called when the user interacts with pydov code. The AbstractHook class
-provides default, empty, implementation of all
-available methods allowing users to only implement the methods for the
-events they need.
+:class:`pydov.util.hooks.AbstractReadHook` and/or
+:class:`pydov.util.hooks.AbstractInjectHook`. An instance of this class can
+then by registered as a pydov hook, and implemented methods will be
+subsequently be called when the user interacts with pydov code. Both classes
+provide default, empty, implementation of all available methods allowing users
+to only implement the methods for the events they need.
 
 Note that certain events (notably the XML related events) will be called from
 multiple threads simultaneously, so implementations must be threadsafe or use
@@ -41,8 +41,21 @@ as a result can halt or slow down usage of the package, depending on the
 implementation of the hooks itself.
 
 
-Available event hooks
-.....................
+Available read-only event hooks
+...............................
+
+Read-only events allow you to implement custom behaviour when certain events
+occur while running pydov code. They are read-only in the sense that they only
+receive data about the event (in form of method parameters) and cannot influence
+the execution of pydov's internal code.
+
+They are generally safe to use. Mind that they are executed inline in a
+blocking way and consequently can slow down pydov queries depending on your
+implementation.
+
+To receive read-only event hooks your class should subclass
+:class:`pydov.util.hooks.AbstractReadHook`. The following event hooks are
+available:
 
 meta_received (url: str, response: bytes)
     This method will be called whenever a response for a metadata request is
@@ -53,15 +66,6 @@ meta_received (url: str, response: bytes)
     requests for MD_Metadata, FC_FeatureCatalogue and XSD schemas. These are
     all calls except for WFS GetFeature requests and XML downloads of DOV data
     - these are other hooks.
-
-inject_meta_response (url: str) -> bytes
-    This method can be used to inject a custom response for a metadata request
-    with the given URL. There is one parameter `url` with the full URL of the
-    metadata request.
-
-    When at least one registered hook returns a response for a given URL,
-    the remote call is not executed and instead the response from the
-    last registered hook (that is non-null) is used instead.
 
 wfs_search_init (typename: str)
     This method will be called whenever a WFS search is initiated. There is
@@ -76,15 +80,6 @@ wfs_search_result_received (query: etree.ElementTree, features: etree.ElementTre
     parameters, `query` is the WFS GetFeature request sent to the server and
     `features` is the FeatureCollection received in response.
 
-inject_wfs_getfeature_response (query: etree.ElementTree) -> bytes
-    This method can be used to inject a custom response for a WFS GetFeature
-    request with the given query. There is one parameter `query` with the WFS
-    GetFeature request sent to the server.
-
-    When at least one registered hook returns a response for a given query,
-    the remote call is not executed and instead the response from the
-    last registered hook (that is non-null) is used instead.
-
 xml_received (pkey_object: str, xml: bytes)
     This method will be called whenever an XML document is received, either
     from the cache or from the remote DOV service. There are two parameters,
@@ -94,19 +89,6 @@ xml_received (pkey_object: str, xml: bytes)
     Because of parallel processing, this method will be called simultaneously
     from multiple threads. Make sure your implementation is threadsafe or uses
     locking.
-
-inject_xml_response (pkey_object: str) -> bytes
-    This method can be used to inject a custom response for a DOV XML
-    request for the given object. There is one parameter `pkey_object` with
-    the permanent key of the DOV object.
-
-    When at least one registered hook returns a response for a given pkey,
-    the remote call is not executed and instead the response from the
-    last registered hook (that is non-null) is used instead.
-
-    Because of parallel processing, this method will be called
-    simultaneously from multiple threads. Make sure your implementation is
-    threadsafe or uses locking.
 
 xml_cache_hit (pkey_object: str)
     This method will be called whenever an XML document is reused from the
@@ -125,6 +107,54 @@ xml_downloaded (pkey_object: str)
     Because of parallel processing, this method will be called simultaneously
     from multiple threads. Make sure your implementation is threadsafe or uses
     locking.
+
+
+Available inject event hooks
+............................
+
+Contrary to read-only hooks described above, inject events allow you to inject
+custom behaviour at certain points in pydov's execution stack.
+
+They should be used with extreme care! It is probably wise to open an issue in
+Github if you find yourself needing these hooks, since they are most likely not
+the right solution for what you're trying to achieve.
+
+To receive inject event hooks your class should subclass
+:class:`pydov.util.hooks.AbstractInjectHook`. The following event hooks are
+available:
+
+
+inject_meta_response (url: str) -> bytes
+    This method can be used to inject a custom response for a metadata request
+    with the given URL. There is one parameter `url` with the full URL of the
+    metadata request.
+
+    When at least one registered hook returns a response for a given URL,
+    the remote call is not executed and instead the response from the
+    last registered hook (that is non-null) is used instead.
+
+inject_wfs_getfeature_response (query: etree.ElementTree) -> bytes
+    This method can be used to inject a custom response for a WFS GetFeature
+    request with the given query. There is one parameter `query` with the WFS
+    GetFeature request sent to the server.
+
+    When at least one registered hook returns a response for a given query,
+    the remote call is not executed and instead the response from the
+    last registered hook (that is non-null) is used instead.
+
+inject_xml_response (pkey_object: str) -> bytes
+    This method can be used to inject a custom response for a DOV XML
+    request for the given object. There is one parameter `pkey_object` with
+    the permanent key of the DOV object.
+
+    When at least one registered hook returns a response for a given pkey,
+    the remote call is not executed and instead the response from the
+    last registered hook (that is non-null) is used instead.
+
+    Because of parallel processing, this method will be called
+    simultaneously from multiple threads. Make sure your implementation is
+    threadsafe or uses locking.
+
 
 Integrating custom hooks
 ........................

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -178,11 +178,11 @@ completed and an XML document is requested.::
     import pydov
     import pydov.util.hooks
 
-    class MyHooks(pydov.util.hooks.AbstractHook):
+    class MyHooks(pydov.util.hooks.AbstractReadHook):
         def wfs_search_result(self, number_of_results):
             print('WFS search completed with %i results.' % number_of_results)
 
-        def xml_requested(self, pkey_object):
-            print('Requested XML document for object %s.' % pkey_object)
+        def xml_received(self, pkey_object, xml):
+            print('Received XML document for object %s.' % pkey_object)
 
     pydov.hooks.append(MyHooks())

--- a/pydov/__init__.py
+++ b/pydov/__init__.py
@@ -2,16 +2,19 @@
 import requests
 
 import pydov.util.caching
-from pydov.util.hooks import SimpleStatusHook
+from pydov.util.hooks import (
+    SimpleStatusHook,
+    Hooks,
+)
 
 __author__ = """DOV-Vlaanderen"""
 __version__ = '1.0.0'
 
 cache = pydov.util.caching.GzipTextFileCache()
 
-hooks = [
-    SimpleStatusHook(),
-]
+hooks = Hooks(
+    (SimpleStatusHook(),)
+)
 
 # Package wide requests session object. This increases performance as using a
 # session object allows connection pooling and TCP connection reuse.

--- a/pydov/search/abstract.py
+++ b/pydov/search/abstract.py
@@ -566,7 +566,6 @@ class AbstractSearch(AbstractCommon):
 
         for hook in pydov.hooks:
             hook.wfs_search_init(typename)
-            hook.wfs_search_query(wfs_getfeature_xml)
 
         tree = None
         for hook in pydov.hooks:

--- a/pydov/search/abstract.py
+++ b/pydov/search/abstract.py
@@ -119,7 +119,7 @@ class AbstractSearch(AbstractCommon):
         if AbstractSearch.__wfs is None:
             capabilities = None
 
-            for hook in pydov.hooks:
+            for hook in pydov.hooks.get_inject_hooks():
                 capa = hook.inject_meta_response(
                     build_dov_url('geoserver/wfs') + '?version=1.1.0')
                 if capa is not None:
@@ -133,7 +133,7 @@ class AbstractSearch(AbstractCommon):
                     url=build_dov_url('geoserver/wfs'), version="1.1.0",
                     xml=capabilities)
 
-            for hook in pydov.hooks:
+            for hook in pydov.hooks.get_read_hooks():
                 hook.meta_received(
                     build_dov_url('geoserver/wfs') + '?version=1.1.0',
                     etree.tostring(AbstractSearch.__wfs._capabilities,
@@ -564,11 +564,11 @@ class AbstractSearch(AbstractCommon):
             propertyname=propertyname
         )
 
-        for hook in pydov.hooks:
+        for hook in pydov.hooks.get_read_hooks():
             hook.wfs_search_init(typename)
 
         tree = None
-        for hook in pydov.hooks:
+        for hook in pydov.hooks.get_inject_hooks():
             t = hook.inject_wfs_getfeature_response(wfs_getfeature_xml)
             if t is not None:
                 tree = t
@@ -697,7 +697,7 @@ class AbstractSearch(AbstractCommon):
                 'Reached the limit of {:d} returned features. Please split up '
                 'the query to ensure getting all results.'.format(10000))
 
-        for hook in pydov.hooks:
+        for hook in pydov.hooks.get_read_hooks():
             hook.wfs_search_result(int(tree.get('numberOfFeatures')))
             hook.wfs_search_result_received(getfeature, tree)
 

--- a/pydov/search/abstract.py
+++ b/pydov/search/abstract.py
@@ -569,7 +569,7 @@ class AbstractSearch(AbstractCommon):
 
         tree = None
         for hook in pydov.hooks:
-            t = hook.inject_wfs_result_features(wfs_getfeature_xml)
+            t = hook.inject_wfs_getfeature_response(wfs_getfeature_xml)
             if t is not None:
                 tree = t
 
@@ -699,7 +699,7 @@ class AbstractSearch(AbstractCommon):
 
         for hook in pydov.hooks:
             hook.wfs_search_result(int(tree.get('numberOfFeatures')))
-            hook.wfs_search_result_features(getfeature, tree)
+            hook.wfs_search_result_received(getfeature, tree)
 
         return tree
 

--- a/pydov/search/abstract.py
+++ b/pydov/search/abstract.py
@@ -23,6 +23,7 @@ from pydov.util.errors import (
     InvalidFieldError,
     WfsGetFeatureError,
 )
+from pydov.util.hooks import HookRunner
 
 
 class AbstractCommon(object):
@@ -118,7 +119,7 @@ class AbstractSearch(AbstractCommon):
         """
         if AbstractSearch.__wfs is None:
 
-            capabilities = pydov.hooks._execute_inject_meta_response(
+            capabilities = HookRunner.execute_inject_meta_response(
                 build_dov_url('geoserver/wfs') + '?version=1.1.0'
             )
 
@@ -564,7 +565,7 @@ class AbstractSearch(AbstractCommon):
         for hook in pydov.hooks.get_read_hooks():
             hook.wfs_search_init(typename)
 
-        tree = pydov.hooks._execute_inject_wfs_getfeature_response(
+        tree = HookRunner.execute_inject_wfs_getfeature_response(
             wfs_getfeature_xml)
 
         if tree is not None:

--- a/pydov/search/abstract.py
+++ b/pydov/search/abstract.py
@@ -117,13 +117,10 @@ class AbstractSearch(AbstractCommon):
         to all subclasses and instances.
         """
         if AbstractSearch.__wfs is None:
-            capabilities = None
 
-            for hook in pydov.hooks.get_inject_hooks():
-                capa = hook.inject_meta_response(
-                    build_dov_url('geoserver/wfs') + '?version=1.1.0')
-                if capa is not None:
-                    capabilities = capa
+            capabilities = pydov.hooks._execute_inject_meta_response(
+                build_dov_url('geoserver/wfs') + '?version=1.1.0'
+            )
 
             if capabilities is None:
                 AbstractSearch.__wfs = WebFeatureService(
@@ -567,11 +564,8 @@ class AbstractSearch(AbstractCommon):
         for hook in pydov.hooks.get_read_hooks():
             hook.wfs_search_init(typename)
 
-        tree = None
-        for hook in pydov.hooks.get_inject_hooks():
-            t = hook.inject_wfs_getfeature_response(wfs_getfeature_xml)
-            if t is not None:
-                tree = t
+        tree = pydov.hooks._execute_inject_wfs_getfeature_response(
+            wfs_getfeature_xml)
 
         if tree is not None:
             return tree, wfs_getfeature_xml

--- a/pydov/search/abstract.py
+++ b/pydov/search/abstract.py
@@ -131,12 +131,11 @@ class AbstractSearch(AbstractCommon):
                     url=build_dov_url('geoserver/wfs'), version="1.1.0",
                     xml=capabilities)
 
-            for hook in pydov.hooks.get_read_hooks():
-                hook.meta_received(
-                    build_dov_url('geoserver/wfs') + '?version=1.1.0',
-                    etree.tostring(AbstractSearch.__wfs._capabilities,
-                                   encoding='utf8')
-                )
+            HookRunner.execute_meta_received(
+                build_dov_url('geoserver/wfs') + '?version=1.1.0',
+                etree.tostring(AbstractSearch.__wfs._capabilities,
+                               encoding='utf8')
+            )
 
     def _init_namespace(self):
         """Initialise the WFS namespace associated with the layer.
@@ -562,8 +561,7 @@ class AbstractSearch(AbstractCommon):
             propertyname=propertyname
         )
 
-        for hook in pydov.hooks.get_read_hooks():
-            hook.wfs_search_init(typename)
+        HookRunner.execute_wfs_search_init(typename)
 
         tree = HookRunner.execute_inject_wfs_getfeature_response(
             wfs_getfeature_xml)
@@ -692,9 +690,8 @@ class AbstractSearch(AbstractCommon):
                 'Reached the limit of {:d} returned features. Please split up '
                 'the query to ensure getting all results.'.format(10000))
 
-        for hook in pydov.hooks.get_read_hooks():
-            hook.wfs_search_result(int(tree.get('numberOfFeatures')))
-            hook.wfs_search_result_received(getfeature, tree)
+        HookRunner.execute_wfs_search_result(int(tree.get('numberOfFeatures')))
+        HookRunner.execute_wfs_search_result_received(getfeature, tree)
 
         return tree
 

--- a/pydov/types/abstract.py
+++ b/pydov/types/abstract.py
@@ -613,7 +613,7 @@ class AbstractDovType(AbstractTypeCommon):
             return pydov.cache.get(self.pkey + '.xml')
         else:
             xml = get_dov_xml(self.pkey + '.xml')
-            for hook in pydov.hooks:
+            for hook in pydov.hooks.get_read_hooks():
                 hook.xml_downloaded(self.pkey)
             return xml
 

--- a/pydov/types/abstract.py
+++ b/pydov/types/abstract.py
@@ -609,9 +609,6 @@ class AbstractDovType(AbstractTypeCommon):
             The raw XML data of this DOV object as bytes.
 
         """
-        for hook in pydov.hooks:
-            hook.xml_requested(self.pkey)
-
         if pydov.cache:
             return pydov.cache.get(self.pkey + '.xml')
         else:

--- a/pydov/types/abstract.py
+++ b/pydov/types/abstract.py
@@ -22,6 +22,7 @@ from ..util.errors import (
     XmlParseError,
     XmlParseWarning,
 )
+from ..util.hooks import HookRunner
 
 
 class AbstractTypeCommon(AbstractCommon):
@@ -613,8 +614,7 @@ class AbstractDovType(AbstractTypeCommon):
             return pydov.cache.get(self.pkey + '.xml')
         else:
             xml = get_dov_xml(self.pkey + '.xml')
-            for hook in pydov.hooks.get_read_hooks():
-                hook.xml_downloaded(self.pkey)
+            HookRunner.execute_xml_downloaded(self.pkey)
             return xml
 
     def _parse_subtypes(self, xml):

--- a/pydov/util/caching.py
+++ b/pydov/util/caching.py
@@ -30,8 +30,7 @@ class AbstractCache(object):
 
         """
         xml = get_dov_xml(url)
-        for hook in pydov.hooks.get_read_hooks():
-            hook.xml_downloaded(url.rstrip('.xml'))
+        HookRunner.execute_xml_downloaded(url.rstrip('.xml'))
         return xml
 
     def _emit_cache_hit(self, url):
@@ -43,8 +42,7 @@ class AbstractCache(object):
             Permanent URL to a DOV object.
 
         """
-        for hook in pydov.hooks.get_read_hooks():
-            hook.xml_cache_hit(url.rstrip('.xml'))
+        HookRunner.execute_xml_cache_hit(url.rstrip('.xml'))
 
     def get(self, url):
         """Get the XML data for the DOV object referenced by the given URL.
@@ -271,8 +269,7 @@ class AbstractFileCache(AbstractCache):
         data = HookRunner.execute_inject_xml_response(url)
 
         if data is not None:
-            for hook in pydov.hooks.get_read_hooks():
-                hook.xml_received(url, data)
+            HookRunner.execute_xml_received(url, data)
             return data
 
         if self._is_valid(datatype, key):
@@ -280,8 +277,7 @@ class AbstractFileCache(AbstractCache):
                 self._emit_cache_hit(url)
                 data = self._load(datatype, key).encode('utf-8')
 
-                for hook in pydov.hooks.get_read_hooks():
-                    hook.xml_received(url, data)
+                HookRunner.execute_xml_received(url, data)
                 return data
 
             except Exception:

--- a/pydov/util/caching.py
+++ b/pydov/util/caching.py
@@ -29,7 +29,7 @@ class AbstractCache(object):
 
         """
         xml = get_dov_xml(url)
-        for hook in pydov.hooks:
+        for hook in pydov.hooks.get_read_hooks():
             hook.xml_downloaded(url.rstrip('.xml'))
         return xml
 
@@ -42,7 +42,7 @@ class AbstractCache(object):
             Permanent URL to a DOV object.
 
         """
-        for hook in pydov.hooks:
+        for hook in pydov.hooks.get_read_hooks():
             hook.xml_cache_hit(url.rstrip('.xml'))
 
     def get(self, url):
@@ -268,13 +268,13 @@ class AbstractFileCache(AbstractCache):
         datatype, key = self._get_type_key_from_url(url)
 
         data = None
-        for hook in pydov.hooks:
+        for hook in pydov.hooks.get_inject_hooks():
             x = hook.inject_xml_response(url)
             if x is not None:
                 data = x
 
         if data is not None:
-            for hook in pydov.hooks:
+            for hook in pydov.hooks.get_read_hooks():
                 hook.xml_received(url, data)
             return data
 
@@ -283,7 +283,7 @@ class AbstractFileCache(AbstractCache):
                 self._emit_cache_hit(url)
                 data = self._load(datatype, key).encode('utf-8')
 
-                for hook in pydov.hooks:
+                for hook in pydov.hooks.get_read_hooks():
                     hook.xml_received(url, data)
                 return data
 

--- a/pydov/util/caching.py
+++ b/pydov/util/caching.py
@@ -267,11 +267,7 @@ class AbstractFileCache(AbstractCache):
         """
         datatype, key = self._get_type_key_from_url(url)
 
-        data = None
-        for hook in pydov.hooks.get_inject_hooks():
-            x = hook.inject_xml_response(url)
-            if x is not None:
-                data = x
+        data = pydov.hooks._execute_inject_xml_response(url)
 
         if data is not None:
             for hook in pydov.hooks.get_read_hooks():

--- a/pydov/util/caching.py
+++ b/pydov/util/caching.py
@@ -9,6 +9,7 @@ import tempfile
 
 import pydov
 from pydov.util.dovutil import get_dov_xml
+from pydov.util.hooks import HookRunner
 
 
 class AbstractCache(object):
@@ -267,7 +268,7 @@ class AbstractFileCache(AbstractCache):
         """
         datatype, key = self._get_type_key_from_url(url)
 
-        data = pydov.hooks._execute_inject_xml_response(url)
+        data = HookRunner.execute_inject_xml_response(url)
 
         if data is not None:
             for hook in pydov.hooks.get_read_hooks():

--- a/pydov/util/caching.py
+++ b/pydov/util/caching.py
@@ -271,7 +271,7 @@ class AbstractFileCache(AbstractCache):
         for hook in pydov.hooks:
             x = hook.inject_xml_response(url)
             if x is not None:
-                data = x.encode('utf8')
+                data = x
 
         if data is not None:
             for hook in pydov.hooks:

--- a/pydov/util/caching.py
+++ b/pydov/util/caching.py
@@ -296,8 +296,6 @@ class AbstractFileCache(AbstractCache):
         except Exception:
             pass
 
-        for hook in pydov.hooks:
-            hook.xml_received(url, data)
         return data
 
     def clean(self):

--- a/pydov/util/caching.py
+++ b/pydov/util/caching.py
@@ -269,13 +269,13 @@ class AbstractFileCache(AbstractCache):
 
         data = None
         for hook in pydov.hooks:
-            x = hook.inject_xml_retrieved(url)
+            x = hook.inject_xml_response(url)
             if x is not None:
                 data = x.encode('utf8')
 
         if data is not None:
             for hook in pydov.hooks:
-                hook.xml_retrieved(url, data)
+                hook.xml_received(url, data)
             return data
 
         if self._is_valid(datatype, key):
@@ -284,7 +284,7 @@ class AbstractFileCache(AbstractCache):
                 data = self._load(datatype, key).encode('utf-8')
 
                 for hook in pydov.hooks:
-                    hook.xml_retrieved(url, data)
+                    hook.xml_received(url, data)
                 return data
 
             except Exception:
@@ -297,7 +297,7 @@ class AbstractFileCache(AbstractCache):
             pass
 
         for hook in pydov.hooks:
-            hook.xml_retrieved(url, data)
+            hook.xml_received(url, data)
         return data
 
     def clean(self):

--- a/pydov/util/caching.py
+++ b/pydov/util/caching.py
@@ -7,7 +7,6 @@ import re
 import shutil
 import tempfile
 
-import pydov
 from pydov.util.dovutil import get_dov_xml
 from pydov.util.hooks import HookRunner
 

--- a/pydov/util/dovutil.py
+++ b/pydov/util/dovutil.py
@@ -59,11 +59,7 @@ def get_xsd_schema(url):
         The raw XML data of this XSD schema as bytes.
 
     """
-    response = None
-    for hook in pydov.hooks.get_inject_hooks():
-        r = hook.inject_meta_response(url)
-        if r is not None:
-            response = r.encode('utf8')
+    response = pydov.hooks._execute_inject_meta_response(url)
 
     if response is None:
         response = get_remote_url(url)
@@ -87,11 +83,7 @@ def get_dov_xml(url):
         The raw XML data of this DOV object as bytes.
 
     """
-    response = None
-    for hook in pydov.hooks.get_inject_hooks():
-        r = hook.inject_xml_response(url)
-        if r is not None:
-            response = r
+    response = pydov.hooks._execute_inject_xml_response(url)
 
     if response is None:
         response = get_remote_url(url)

--- a/pydov/util/dovutil.py
+++ b/pydov/util/dovutil.py
@@ -65,8 +65,8 @@ def get_xsd_schema(url):
     if response is None:
         response = get_remote_url(url)
 
-    for hook in pydov.hooks.get_read_hooks():
-        hook.meta_received(url, response)
+    HookRunner.execute_meta_received(url, response)
+
     return response
 
 
@@ -89,8 +89,7 @@ def get_dov_xml(url):
     if response is None:
         response = get_remote_url(url)
 
-    for hook in pydov.hooks.get_read_hooks():
-        hook.xml_received(url, response)
+    HookRunner.execute_xml_received(url, response)
 
     return response
 

--- a/pydov/util/dovutil.py
+++ b/pydov/util/dovutil.py
@@ -91,7 +91,7 @@ def get_dov_xml(url):
     for hook in pydov.hooks:
         r = hook.inject_xml_response(url)
         if r is not None:
-            response = r.encode('utf8')
+            response = r
 
     if response is None:
         response = get_remote_url(url)

--- a/pydov/util/dovutil.py
+++ b/pydov/util/dovutil.py
@@ -60,7 +60,7 @@ def get_xsd_schema(url):
 
     """
     response = None
-    for hook in pydov.hooks:
+    for hook in pydov.hooks.get_inject_hooks():
         r = hook.inject_meta_response(url)
         if r is not None:
             response = r.encode('utf8')
@@ -68,7 +68,7 @@ def get_xsd_schema(url):
     if response is None:
         response = get_remote_url(url)
 
-    for hook in pydov.hooks:
+    for hook in pydov.hooks.get_read_hooks():
         hook.meta_received(url, response)
     return response
 
@@ -88,7 +88,7 @@ def get_dov_xml(url):
 
     """
     response = None
-    for hook in pydov.hooks:
+    for hook in pydov.hooks.get_inject_hooks():
         r = hook.inject_xml_response(url)
         if r is not None:
             response = r
@@ -96,7 +96,7 @@ def get_dov_xml(url):
     if response is None:
         response = get_remote_url(url)
 
-    for hook in pydov.hooks:
+    for hook in pydov.hooks.get_read_hooks():
         hook.xml_received(url, response)
 
     return response

--- a/pydov/util/dovutil.py
+++ b/pydov/util/dovutil.py
@@ -5,6 +5,7 @@ import os
 from owslib.etree import etree
 from pydov.util.errors import XmlParseError
 import pydov
+from pydov.util.hooks import HookRunner
 
 
 def build_dov_url(path):
@@ -59,7 +60,7 @@ def get_xsd_schema(url):
         The raw XML data of this XSD schema as bytes.
 
     """
-    response = pydov.hooks._execute_inject_meta_response(url)
+    response = HookRunner.execute_inject_meta_response(url)
 
     if response is None:
         response = get_remote_url(url)
@@ -83,7 +84,7 @@ def get_dov_xml(url):
         The raw XML data of this DOV object as bytes.
 
     """
-    response = pydov.hooks._execute_inject_xml_response(url)
+    response = HookRunner.execute_inject_xml_response(url)
 
     if response is None:
         response = get_remote_url(url)

--- a/pydov/util/dovutil.py
+++ b/pydov/util/dovutil.py
@@ -59,7 +59,18 @@ def get_xsd_schema(url):
         The raw XML data of this XSD schema as bytes.
 
     """
-    return get_remote_url(url)
+    response = None
+    for hook in pydov.hooks:
+        r = hook.inject_meta_response(url)
+        if r is not None:
+            response = r.encode('utf8')
+
+    if response is None:
+        response = get_remote_url(url)
+
+    for hook in pydov.hooks:
+        hook.meta_received(url, response)
+    return response
 
 
 def get_dov_xml(url):
@@ -76,7 +87,19 @@ def get_dov_xml(url):
         The raw XML data of this DOV object as bytes.
 
     """
-    return get_remote_url(url)
+    response = None
+    for hook in pydov.hooks:
+        r = hook.inject_xml_retrieved(url)
+        if r is not None:
+            response = r.encode('utf8')
+
+    if response is None:
+        response = get_remote_url(url)
+
+    for hook in pydov.hooks:
+        hook.xml_retrieved(url, response)
+
+    return response
 
 
 def parse_dov_xml(xml_data):

--- a/pydov/util/dovutil.py
+++ b/pydov/util/dovutil.py
@@ -89,7 +89,7 @@ def get_dov_xml(url):
     """
     response = None
     for hook in pydov.hooks:
-        r = hook.inject_xml_retrieved(url)
+        r = hook.inject_xml_response(url)
         if r is not None:
             response = r.encode('utf8')
 
@@ -97,7 +97,7 @@ def get_dov_xml(url):
         response = get_remote_url(url)
 
     for hook in pydov.hooks:
-        hook.xml_retrieved(url, response)
+        hook.xml_received(url, response)
 
     return response
 

--- a/pydov/util/hooks.py
+++ b/pydov/util/hooks.py
@@ -120,9 +120,9 @@ class AbstractHook(object):
 
         Returns
         -------
-        bytes, optional
-            The response to use in favor of resolving the URL. Return None to
-            disable this inject hook.
+        xml: bytes, optional
+            The GetFeature response to use in favor of resolving the URL.
+            Return None to disable this inject hook.
 
         """
         return None
@@ -169,9 +169,9 @@ class AbstractHook(object):
 
         Returns
         -------
-        bytes, optional
-            The response to use in favor of resolving the URL. Return None to
-            disable this inject hook.
+        xml : bytes, optional
+            The XML response to use in favor of resolving the URL. Return
+            None to disable this inject hook.
 
         """
         return None

--- a/pydov/util/hooks.py
+++ b/pydov/util/hooks.py
@@ -7,8 +7,6 @@ from multiprocessing import Lock
 import sys
 import time
 
-from owslib.etree import etree
-
 
 class AbstractHook(object):
     """Abstract base class for custom hook implementations.

--- a/pydov/util/hooks.py
+++ b/pydov/util/hooks.py
@@ -7,6 +7,8 @@ from multiprocessing import Lock
 import sys
 import time
 
+import pydov
+
 
 class Hooks(list):
     """Runtime representation of registered pydov hooks, i.e. a list of
@@ -35,7 +37,10 @@ class Hooks(list):
         """
         return (h for h in self if isinstance(h, AbstractInjectHook))
 
-    def __execute_inject(self, hook_name, args):
+
+class HookRunner(object):
+    @staticmethod
+    def __execute_inject(hook_name, args):
         """Execute the inject hook with given name for all registered hooks
         and return the last non-null result.
 
@@ -54,24 +59,30 @@ class Hooks(list):
 
         """
         result = None
-        for h in self.get_inject_hooks():
+        for h in pydov.hooks.get_inject_hooks():
             r = getattr(h, hook_name)(*args)
             if r is not None:
                 result = r
         return result
 
-    def _execute_inject_meta_response(self, url):
+    @staticmethod
+    def execute_inject_meta_response(url):
         """Execute the inject_meta_response hooks for the given URL. """
-        return self.__execute_inject('inject_meta_response', [url])
+        return HookRunner.__execute_inject(
+            'inject_meta_response', [url])
 
-    def _execute_inject_wfs_getfeature_response(self, query):
+    @staticmethod
+    def execute_inject_wfs_getfeature_response(query):
         """Execute the inject_wfs_getfeature_response hooks for the given
         query."""
-        return self.__execute_inject('inject_wfs_getfeature_response', [query])
+        return HookRunner.__execute_inject(
+            'inject_wfs_getfeature_response', [query])
 
-    def _execute_inject_xml_response(self, pkey_object):
+    @staticmethod
+    def execute_inject_xml_response(pkey_object):
         """Execute the inject_xml_response hooks for the given pkey_object."""
-        return self.__execute_inject('inject_xml_response', [pkey_object])
+        return HookRunner.__execute_inject(
+            'inject_xml_response', [pkey_object])
 
 
 class AbstractReadHook(object):

--- a/pydov/util/hooks.py
+++ b/pydov/util/hooks.py
@@ -122,7 +122,7 @@ class AbstractHook(object):
 
         Returns
         -------
-        etree.ElementTree, optional
+        bytes, optional
             The response to use in favor of resolving the URL. Return None to
             disable this inject hook.
 
@@ -171,7 +171,7 @@ class AbstractHook(object):
 
         Returns
         -------
-        etree.ElementTree, optional
+        bytes, optional
             The response to use in favor of resolving the URL. Return None to
             disable this inject hook.
 

--- a/pydov/util/hooks.py
+++ b/pydov/util/hooks.py
@@ -89,7 +89,7 @@ class AbstractHook(object):
         """
         pass
 
-    def wfs_search_result_features(self, query, features):
+    def wfs_search_result_received(self, query, features):
         """Called after a WFS search finished.
 
         Includes both the GetFeature query as well as the response from the
@@ -105,7 +105,7 @@ class AbstractHook(object):
         """
         pass
 
-    def inject_wfs_result_features(self, query):
+    def inject_wfs_getfeature_response(self, query):
         """Inject a response for a WFS GetFeature request.
 
         This allows to intercept a WFS GetFeature request and return a
@@ -129,8 +129,8 @@ class AbstractHook(object):
         """
         return None
 
-    def xml_retrieved(self, pkey_object, xml):
-        """Called when the XML of a given object is retrieved, either from
+    def xml_received(self, pkey_object, xml):
+        """Called when the XML of a given object is received, either from
         the cache or from the remote DOV service.
 
         Includes the permanent key of the DOV object as well as the full XML
@@ -150,7 +150,7 @@ class AbstractHook(object):
         """
         pass
 
-    def inject_xml_retrieved(self, pkey_object):
+    def inject_xml_response(self, pkey_object):
         """Inject a response for a DOV XML request.
 
         This allows to intercept a DOV XML request and return a response of

--- a/pydov/util/hooks.py
+++ b/pydov/util/hooks.py
@@ -42,7 +42,7 @@ class HookRunner(object):
     """Class for executing registered hooks."""
     @staticmethod
     def __execute_read(hook_name, args):
-        """Execute the read hook with the given name for all registeres hooks.
+        """Execute the read hook with the given name for all registered hooks.
 
         Parameters
         ----------

--- a/pydov/util/hooks.py
+++ b/pydov/util/hooks.py
@@ -235,6 +235,9 @@ class HookRunner(object):
 class AbstractReadHook(object):
     """Abstract base class for custom hook implementations.
 
+    This class contains all read-only hooks: i.e. hooks receiving events but
+    otherwise not interfering with pydov's execution stack.
+
     Provides all available methods with a default implementation to do
     nothing. This allows for hook subclasses to only implement the events
     they need.
@@ -352,6 +355,21 @@ class AbstractReadHook(object):
 
 
 class AbstractInjectHook(object):
+    """Abstract base class for custom hook implementations.
+
+    This class contains all inject hooks: i.e. hooks receiving events and
+    possibly returning custom data for injection into pydov's execution stack.
+
+    Inject hooks allow you to capture and intercept remote server calls,
+    influencing pydov's inner workings. Use with care! If you reached this
+    part of the code, it is probably wise to open an issue in Github,
+    since this is most likely not what you need.
+
+    Provides all available methods with a default implementation to do
+    nothing. This allows for hook subclasses to only implement the events
+    they need.
+
+    """
     def inject_meta_response(self, url):
         """Inject a response for a metadata request.
 

--- a/pydov/util/hooks.py
+++ b/pydov/util/hooks.py
@@ -39,6 +39,22 @@ class Hooks(list):
 
 
 class HookRunner(object):
+    """Class for executing registered hooks."""
+    @staticmethod
+    def __execute_read(hook_name, args):
+        """Execute the read hook with the given name for all registeres hooks.
+
+        Parameters
+        ----------
+        hook_name : str
+            Name of the hook function to execute.
+        args : list
+            List of arguments to pass to the hook function call.
+
+        """
+        for h in pydov.hooks.get_read_hooks():
+            getattr(h, hook_name)(*args)
+
     @staticmethod
     def __execute_inject(hook_name, args):
         """Execute the inject hook with given name for all registered hooks
@@ -66,21 +82,152 @@ class HookRunner(object):
         return result
 
     @staticmethod
+    def execute_meta_received(url, response):
+        """Execute the meta_received method for all registered hooks.
+
+        Parameters
+        ----------
+        url : str
+            URL of the metadata request.
+        response : bytes
+            The raw response as received from resolving the URL.
+
+        """
+        HookRunner.__execute_read('meta_received', [url, response])
+
+    @staticmethod
+    def execute_wfs_search_init(typename):
+        """Execute the wfs_search_init method for all registered hooks.
+
+        Parameters
+        ----------
+        typename : str
+            The typename (layername) of the WFS service used for searching.
+
+        """
+        HookRunner.__execute_read('wfs_search_init', [typename])
+
+    @staticmethod
+    def execute_wfs_search_result(number_of_results):
+        """Execute the wfs_search_result method for all registered hooks.
+
+        Parameters
+        ----------
+        number_of_results : int
+            The number of features returned by the WFS search.
+
+        """
+        HookRunner.__execute_read('wfs_search_result', [number_of_results])
+
+    @staticmethod
+    def execute_wfs_search_result_received(query, features):
+        """Execute the wfs_search_result_received method for all registered
+        hooks.
+
+        Parameters
+        ----------
+        query : etree.ElementTree
+            The WFS GetFeature request sent to the WFS server.
+        features : etree.ElementTree
+            The WFS GetFeature response containings the features.
+
+        """
+        HookRunner.__execute_read('wfs_search_result_received', [
+            query, features])
+
+    @staticmethod
+    def execute_xml_received(pkey_object, xml):
+        """Execute the xml_received method for all registered hooks.
+
+        Parameters
+        ----------
+        pkey_object : str
+            Permanent key of the retrieved object.
+        xml : bytes
+            The raw XML data of this DOV object as bytes.
+
+        """
+        HookRunner.__execute_read('xml_received', [pkey_object, xml])
+
+    @staticmethod
+    def execute_xml_cache_hit(pkey_object):
+        """Execute the xml_cache_hit method for all registered hooks.
+
+        Parameters
+        ----------
+        pkey_object : str
+            Permanent key of the requested object.
+
+        """
+        HookRunner.__execute_read('xml_cache_hit', [pkey_object])
+
+    @staticmethod
+    def execute_xml_downloaded(pkey_object):
+        """Execute the xml_downloaded method for all registered hooks.
+
+        Parameters
+        ----------
+        pkey_object : str
+            Permanent key of the requested object.
+
+        """
+        HookRunner.__execute_read('xml_downloaded', [pkey_object])
+
+    @staticmethod
     def execute_inject_meta_response(url):
-        """Execute the inject_meta_response hooks for the given URL. """
+        """Execute the inject_meta_response method for all registered hooks.
+
+        Parameters
+        ----------
+        url : str
+            URL of the metadata request.
+
+        Returns
+        -------
+        bytes, optional
+            The response to use in favor of resolving the URL. Returns None if
+            this inject hook is unused.
+
+        """
         return HookRunner.__execute_inject(
             'inject_meta_response', [url])
 
     @staticmethod
     def execute_inject_wfs_getfeature_response(query):
-        """Execute the inject_wfs_getfeature_response hooks for the given
-        query."""
+        """Execute the inject_wfs_getfeature_response method for all
+        registered hooks.
+
+        Parameters
+        ----------
+        query : etree.ElementTree
+            The WFS GetFeature request sent to the WFS server.
+
+        Returns
+        -------
+        xml: bytes, optional
+            The GetFeature response to use in favor of resolving the URL.
+            Returns None if this inject hook is unused.
+
+        """
         return HookRunner.__execute_inject(
             'inject_wfs_getfeature_response', [query])
 
     @staticmethod
     def execute_inject_xml_response(pkey_object):
-        """Execute the inject_xml_response hooks for the given pkey_object."""
+        """Execute the inject_xml_response method for all registered hooks.
+
+        Parameters
+        ----------
+        query : etree.ElementTree
+            The WFS GetFeature request sent to the WFS server.
+
+        Returns
+        -------
+        xml : bytes, optional
+            The XML response to use in favor of resolving the URL. Returns
+            None if this inject hook is unused.
+
+        """
         return HookRunner.__execute_inject(
             'inject_xml_response', [pkey_object])
 

--- a/pydov/util/hooks.py
+++ b/pydov/util/hooks.py
@@ -35,6 +35,44 @@ class Hooks(list):
         """
         return (h for h in self if isinstance(h, AbstractInjectHook))
 
+    def __execute_inject(self, hook_name, args):
+        """Execute the inject hook with given name for all registered hooks
+        and return the last non-null result.
+
+        Parameters
+        ----------
+        hook_name : str
+            Name of the hook function to execute.
+        args : list
+            List of arguments to pass to the hook function call.
+
+        Returns
+        -------
+        object or bytes or None
+            Returns the last non-null result of the execution of the inject
+            hook. If all inject hooks return None, return None as well.
+
+        """
+        result = None
+        for h in self.get_inject_hooks():
+            r = getattr(h, hook_name)(*args)
+            if r is not None:
+                result = r
+        return result
+
+    def _execute_inject_meta_response(self, url):
+        """Execute the inject_meta_response hooks for the given URL. """
+        return self.__execute_inject('inject_meta_response', [url])
+
+    def _execute_inject_wfs_getfeature_response(self, query):
+        """Execute the inject_wfs_getfeature_response hooks for the given
+        query."""
+        return self.__execute_inject('inject_wfs_getfeature_response', [query])
+
+    def _execute_inject_xml_response(self, pkey_object):
+        """Execute the inject_xml_response hooks for the given pkey_object."""
+        return self.__execute_inject('inject_xml_response', [pkey_object])
+
 
 class AbstractReadHook(object):
     """Abstract base class for custom hook implementations.

--- a/pydov/util/owsutil.py
+++ b/pydov/util/owsutil.py
@@ -469,7 +469,6 @@ def get_url(url):
         request.encoding = 'utf-8'
         response = request.text.encode('utf8')
 
-    for hook in pydov.hooks.get_read_hooks():
-        hook.meta_received(url, response)
+    HookRunner.execute_meta_received(url, response)
 
     return response

--- a/pydov/util/owsutil.py
+++ b/pydov/util/owsutil.py
@@ -461,7 +461,18 @@ def get_url(url):
         Response containing the result of the GET request.
 
     """
+    response = None
+    for hook in pydov.hooks:
+        r = hook.inject_meta_response(url)
+        if r is not None:
+            response = r.encode('utf8')
 
-    request = pydov.session.get(url, timeout=pydov.request_timeout)
-    request.encoding = 'utf-8'
-    return request.text.encode('utf8')
+    if response is None:
+        request = pydov.session.get(url, timeout=pydov.request_timeout)
+        request.encoding = 'utf-8'
+        response = request.text.encode('utf8')
+
+    for hook in pydov.hooks:
+        hook.meta_received(url, response)
+
+    return response

--- a/pydov/util/owsutil.py
+++ b/pydov/util/owsutil.py
@@ -462,7 +462,7 @@ def get_url(url):
 
     """
     response = None
-    for hook in pydov.hooks:
+    for hook in pydov.hooks.get_inject_hooks():
         r = hook.inject_meta_response(url)
         if r is not None:
             response = r.encode('utf8')
@@ -472,7 +472,7 @@ def get_url(url):
         request.encoding = 'utf-8'
         response = request.text.encode('utf8')
 
-    for hook in pydov.hooks:
+    for hook in pydov.hooks.get_read_hooks():
         hook.meta_received(url, response)
 
     return response

--- a/pydov/util/owsutil.py
+++ b/pydov/util/owsutil.py
@@ -461,11 +461,7 @@ def get_url(url):
         Response containing the result of the GET request.
 
     """
-    response = None
-    for hook in pydov.hooks.get_inject_hooks():
-        r = hook.inject_meta_response(url)
-        if r is not None:
-            response = r.encode('utf8')
+    response = pydov.hooks._execute_inject_meta_response(url)
 
     if response is None:
         request = pydov.session.get(url, timeout=pydov.request_timeout)

--- a/pydov/util/owsutil.py
+++ b/pydov/util/owsutil.py
@@ -17,6 +17,7 @@ from .errors import (
     MetadataNotFoundError,
     FeatureCatalogueNotFoundError,
 )
+from .hooks import HookRunner
 
 
 def __get_namespaces():
@@ -461,7 +462,7 @@ def get_url(url):
         Response containing the result of the GET request.
 
     """
-    response = pydov.hooks._execute_inject_meta_response(url)
+    response = HookRunner.execute_inject_meta_response(url)
 
     if response is None:
         request = pydov.session.get(url, timeout=pydov.request_timeout)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,14 +4,17 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
 import pydov
+from pydov import Hooks
 
 
 def pytest_runtest_setup():
-    pydov.hooks = []
+    pydov.hooks = Hooks()
+
 
 def pytest_configure(config):
     config.addinivalue_line("markers",
                             "online: mark test that requires internet access")
+
 
 @pytest.fixture(scope='module')
 def monkeymodule():

--- a/tests/test_util_hooks.py
+++ b/tests/test_util_hooks.py
@@ -1,8 +1,11 @@
+import copy
 import datetime
 import pytest
 
 import pydov
 from owslib.fes import PropertyIsEqualTo
+from owslib.etree import etree
+from pydov.search.abstract import AbstractSearch
 from pydov.search.boring import BoringSearch
 from pydov.util.hooks import (
     AbstractHook,
@@ -14,6 +17,52 @@ from tests.test_util_caching import (
     plaintext_cache,
     nocache,
 )
+
+
+@pytest.fixture
+def test_hook_count():
+    """PyTest fixture temporarily disabling default hooks and installing
+    HookCounter."""
+    orig_hooks = pydov.hooks
+    temp_hooks = [HookCounter()]
+
+    pydov.hooks = temp_hooks
+    yield
+
+    pydov.hooks = orig_hooks
+
+
+@pytest.fixture
+def test_hook_types():
+    """PyTest fixture temporarily disabling default hooks and installing
+    HookTester."""
+    orig_hooks = pydov.hooks
+    temp_hooks = [HookTypeTester()]
+
+    pydov.hooks = temp_hooks
+    yield
+
+    pydov.hooks = orig_hooks
+
+
+@pytest.fixture
+def test_hook_inject():
+    """PyTest fixture temporarily disabling default hooks and installing
+    HookInjecter."""
+    orig_hooks = pydov.hooks
+    temp_hooks = [HookInjecter()]
+
+    pydov.hooks = temp_hooks
+    yield
+
+    pydov.hooks = orig_hooks
+
+
+@pytest.fixture
+def force_rebuild_wfs():
+    """PyTest fixture to temporarily reset the cached WFS instance to force
+    reevaluation of the initialisation code and recall meta events."""
+    AbstractSearch._AbstractSearch__wfs = None
 
 
 class HookCounter(AbstractHook):
@@ -61,35 +110,118 @@ class HookCounter(AbstractHook):
         self.count_xml_downloaded += 1
 
 
-@pytest.fixture
-def temp_hooks():
-    """PyTest fixture temporarily disabling default hooks and installing
-    HookCounter."""
-    orig_hooks = pydov.hooks
-    temp_hooks = [HookCounter()]
+class HookTypeTester(AbstractHook):
+    """Hook implementation for testing purposes, testing arguments of all
+    event calls."""
+    def meta_received(self, url, response):
+        assert url is not None
+        assert response is not None
+        assert type(url) is str
+        assert type(response) is bytes
 
-    pydov.hooks = temp_hooks
-    yield
+    def inject_meta_response(self, url):
+        assert url is not None
+        assert type(url) is str
 
-    pydov.hooks = orig_hooks
+    def wfs_search_init(self, typename):
+        assert typename is not None
+        assert type(typename) is str
+
+    def wfs_search_result(self, number_of_results):
+        assert number_of_results is not None
+        assert number_of_results > 0
+        assert type(number_of_results) is int
+
+    def wfs_search_result_received(self, query, features):
+        assert query is not None
+        assert features is not None
+
+    def inject_wfs_getfeature_response(self, query):
+        assert query is not None
+
+    def xml_received(self, pkey_object, xml):
+        assert pkey_object is not None
+        assert xml is not None
+        assert type(pkey_object) is str
+        assert type(xml) is bytes
+
+    def inject_xml_response(self, pkey_object):
+        assert pkey_object is not None
+        assert type(pkey_object) is str
+
+    def xml_cache_hit(self, pkey_object):
+        assert pkey_object is not None
+        assert type(pkey_object) is str
+
+    def xml_downloaded(self, pkey_object):
+        assert pkey_object is not None
+        assert type(pkey_object) is str
 
 
-class TestHooks(object):
+class HookInjecter(AbstractHook):
+    """Hook implementation for testing purposes, testing response injection."""
+    def __init__(self):
+        self.wfs_features = None
+        self.dov_xml = None
+        self.wfs_capabilities = None
+
+    def meta_received(self, url, response):
+        """Save the WFS capabilities document in order to inject later."""
+        if 'geoserver/wfs' in url.lower():
+            self.wfs_capabilities = response
+
+    def inject_meta_response(self, url):
+        """Inject the previously saved WFS capabilities document."""
+        if 'geoserver/wfs' in url.lower() and \
+                self.wfs_capabilities is not None:
+            return self.wfs_capabilities
+
+    def wfs_search_result_received(self, query, features):
+        """Save the WFS GetFeature response in order to adjust and inject
+        later."""
+        self.wfs_features = features
+
+    def inject_wfs_getfeature_response(self, query):
+        """Adapt the previously saved WFS GetFeature response and inject the
+        adapted version."""
+        if self.wfs_features is not None:
+            tree = copy.deepcopy(self.wfs_features)
+            gemeentes = tree.findall(
+                './/{http://dov.vlaanderen.be/ocdov/dov-pub}Boringen/'
+                '{http://dov.vlaanderen.be/ocdov/dov-pub}gemeente')
+            for g in gemeentes:
+                g.text = 'Bevergem'
+            return etree.tostring(tree)
+
+    def xml_received(self, pkey_object, xml):
+        """Save the DOV Xml response in order to adjust and inject later."""
+        self.dov_xml = xml
+
+    def inject_xml_response(self, pkey_object):
+        """Adapt the previously saved DOV XML response and inject the adapted
+        version."""
+        if self.dov_xml is not None:
+            tree = etree.fromstring(self.dov_xml)
+            boormethoden = tree.findall(
+                './/boring/details/boormethode/methode')
+            for b in boormethoden:
+                b.text = 'De Pypere 106 T'
+            return etree.tostring(tree)
+
+
+class TestHookCount(object):
     @pytest.mark.online
     @pytest.mark.skipif(not service_ok(), reason="DOV service is unreachable")
-    def test_wfs_only(self, temp_hooks):
+    def test_wfs_only(self, force_rebuild_wfs, test_hook_count):
         """Test the search method providing both a location and a query.
 
         Test whether a dataframe is returned.
 
         Parameters
         ----------
-        mp_remote_describefeaturetype : pytest.fixture
-            Monkeypatch the call to a remote DescribeFeatureType of the
-            dov-pub:Boringen layer.
-        mp_remote_wfs_feature : pytest.fixture
-            Monkeypatch the call to get WFS features.
-        temp_hooks : pytest.fixture
+        force_rebuild_wfs : pytest.fixture
+            Fixture removing cached WFS capabilities document.
+        test_hook_count : pytest.fixture
             Fixture removing default hooks and installing HookCounter.
 
         """
@@ -115,19 +247,17 @@ class TestHooks(object):
 
     @pytest.mark.online
     @pytest.mark.skipif(not service_ok(), reason="DOV service is unreachable")
-    def test_wfs_and_xml_nocache(self, temp_hooks, nocache):
+    def test_wfs_and_xml_nocache(self, force_rebuild_wfs, test_hook_count,
+                                 nocache):
         """Test the search method providing both a location and a query.
 
         Test whether a dataframe is returned.
 
         Parameters
         ----------
-        mp_remote_describefeaturetype : pytest.fixture
-            Monkeypatch the call to a remote DescribeFeatureType of the
-            dov-pub:Boringen layer.
-        mp_remote_wfs_feature : pytest.fixture
-            Monkeypatch the call to get WFS features.
-        temp_hooks : pytest.fixture
+        force_rebuild_wfs : pytest.fixture
+            Fixture removing cached WFS capabilities document.
+        test_hook_count : pytest.fixture
             Fixture removing default hooks and installing HookCounter.
         nocache : pytest.fixture
             Fixture temporarily disabling caching.
@@ -174,19 +304,17 @@ class TestHooks(object):
     @pytest.mark.parametrize('plaintext_cache',
                              [[datetime.timedelta(minutes=15)]],
                              indirect=['plaintext_cache'])
-    def test_wfs_and_xml_cache(self, temp_hooks, plaintext_cache):
+    def test_wfs_and_xml_cache(self, force_rebuild_wfs, test_hook_count,
+                               plaintext_cache):
         """Test the search method providing both a location and a query.
 
         Test whether a dataframe is returned.
 
         Parameters
         ----------
-        mp_remote_describefeaturetype : pytest.fixture
-            Monkeypatch the call to a remote DescribeFeatureType of the
-            dov-pub:Boringen layer.
-        mp_remote_wfs_feature : pytest.fixture
-            Monkeypatch the call to get WFS features.
-        temp_hooks : pytest.fixture
+        force_rebuild_wfs : pytest.fixture
+            Fixture removing cached WFS capabilities document.
+        test_hook_count : pytest.fixture
             Fixture removing default hooks and installing HookCounter.
         plaintext_cache : pytest.fixture
             Fixture temporarily setting up a testcache with max_age of 1
@@ -206,7 +334,7 @@ class TestHooks(object):
         assert pydov.hooks[0].count_inject_wfs_getfeature_response == 1
 
         assert pydov.hooks[0].count_xml_received == 1
-        assert pydov.hooks[0].count_inject_xml_response == 1
+        assert pydov.hooks[0].count_inject_xml_response == 2
         assert pydov.hooks[0].count_xml_cache_hit == 0
         assert pydov.hooks[0].count_xml_downloaded == 1
 
@@ -222,13 +350,15 @@ class TestHooks(object):
         assert pydov.hooks[0].count_inject_wfs_getfeature_response == 2
 
         assert pydov.hooks[0].count_xml_received == 2
-        assert pydov.hooks[0].count_inject_xml_response == 2
+        assert pydov.hooks[0].count_inject_xml_response == 3
         assert pydov.hooks[0].count_xml_cache_hit == 1
         assert pydov.hooks[0].count_xml_downloaded == 1
 
         assert pydov.hooks[0].count_meta_received > 0
         assert pydov.hooks[0].count_inject_meta_response > 0
 
+
+class TestHookTypes(object):
     @pytest.mark.online
     @pytest.mark.skipif(not service_ok(), reason="DOV service is unreachable")
     def test_default_hooks(self, nocache):
@@ -249,3 +379,50 @@ class TestHooks(object):
 
         boringsearch = BoringSearch()
         df = boringsearch.search(query=query)
+
+    @pytest.mark.online
+    @pytest.mark.skipif(not service_ok(), reason="DOV service is unreachable")
+    def test_hooks(self, force_rebuild_wfs, test_hook_types):
+        """Test the argument types of the hook events.
+
+        Parameters
+        ----------
+        force_rebuild_wfs : pytest.fixture
+            Fixture removing cached WFS capabilities document.
+        test_hook_types : pytest.fixture
+            Fixture removing default hooks and installing HookTester.
+
+        """
+        query = PropertyIsEqualTo(propertyname='boornummer',
+                                  literal='GEO-04/169-BNo-B1')
+
+        boringsearch = BoringSearch()
+        df = boringsearch.search(query=query)
+
+
+class TestHookInject(object):
+    @pytest.mark.online
+    @pytest.mark.skipif(not service_ok(), reason="DOV service is unreachable")
+    def test_hooks_inject(self, force_rebuild_wfs, test_hook_inject):
+        """Test the of the hook inject events.
+
+        Test whether the requests are intercepted correctly.
+
+        Parameters
+        ----------
+        force_rebuild_wfs : pytest.fixture
+            Fixture removing cached WFS capabilities document.
+        test_hook_types : pytest.fixture
+            Fixture removing default hooks and installing HookTester.
+
+        """
+        query = PropertyIsEqualTo(propertyname='boornummer',
+                                  literal='GEO-04/169-BNo-B1')
+
+        boringsearch = BoringSearch()
+
+        boringsearch.search(query=query)
+        df = boringsearch.search(query=query)
+
+        assert df.iloc[0].gemeente == 'Bevergem'
+        assert df.iloc[0].boormethode == 'De Pypere 106 T'

--- a/tests/test_util_hooks.py
+++ b/tests/test_util_hooks.py
@@ -19,55 +19,45 @@ from tests.test_util_caching import (
 class HookCounter(AbstractHook):
     """Hook implementation for testing purposes, counting all event calls."""
     def __init__(self):
+        self.count_meta_received = 0
+        self.count_inject_meta_response = 0
         self.count_wfs_search_init = 0
         self.count_wfs_search_result = 0
+        self.count_wfs_search_result_received = 0
+        self.count_inject_wfs_getfeature_response = 0
+        self.count_xml_received = 0
+        self.count_inject_xml_response = 0
         self.count_xml_cache_hit = 0
         self.count_xml_downloaded = 0
 
+    def meta_received(self, url, response):
+        self.count_meta_received += 1
+
+    def inject_meta_response(self, url):
+        self.count_inject_meta_response += 1
+
     def wfs_search_init(self, typename):
-        """Called upon starting a WFS search.
-
-        Parameters
-        ----------
-        typename : str
-            The typename (layername) of the WFS service used for searching.
-
-        """
         self.count_wfs_search_init += 1
 
     def wfs_search_result(self, number_of_results):
-        """Called after a WFS search finished.
-
-        Parameters
-        ----------
-        number_of_results : int
-            The number of features returned by the WFS search.
-
-        """
         self.count_wfs_search_result += 1
 
+    def wfs_search_result_received(self, query, features):
+        self.count_wfs_search_result_received += 1
+
+    def inject_wfs_getfeature_response(self, query):
+        self.count_inject_wfs_getfeature_response += 1
+
+    def xml_received(self, pkey_object, xml):
+        self.count_xml_received += 1
+
+    def inject_xml_response(self, pkey_object):
+        self.count_inject_xml_response += 1
+
     def xml_cache_hit(self, pkey_object):
-        """Called when the XML document of an object is retrieved from the
-        cache.
-
-        Parameters
-        ----------
-        pkey_object : str
-            Permanent key of the requested object.
-
-        """
         self.count_xml_cache_hit += 1
 
     def xml_downloaded(self, pkey_object):
-        """Called when the XML document of an object is downloaded from the
-        DOV services.
-
-        Parameters
-        ----------
-        pkey_object : str
-            Permanent key of the requested object.
-
-        """
         self.count_xml_downloaded += 1
 
 
@@ -112,8 +102,16 @@ class TestHooks(object):
 
         assert pydov.hooks[0].count_wfs_search_init == 1
         assert pydov.hooks[0].count_wfs_search_result == 1
+        assert pydov.hooks[0].count_wfs_search_result_received == 1
+        assert pydov.hooks[0].count_inject_wfs_getfeature_response == 1
+
+        assert pydov.hooks[0].count_xml_received == 0
+        assert pydov.hooks[0].count_inject_xml_response == 0
         assert pydov.hooks[0].count_xml_cache_hit == 0
         assert pydov.hooks[0].count_xml_downloaded == 0
+
+        assert pydov.hooks[0].count_meta_received > 0
+        assert pydov.hooks[0].count_inject_meta_response > 0
 
     @pytest.mark.online
     @pytest.mark.skipif(not service_ok(), reason="DOV service is unreachable")
@@ -144,16 +142,32 @@ class TestHooks(object):
 
         assert pydov.hooks[0].count_wfs_search_init == 1
         assert pydov.hooks[0].count_wfs_search_result == 1
+        assert pydov.hooks[0].count_wfs_search_result_received == 1
+        assert pydov.hooks[0].count_inject_wfs_getfeature_response == 1
+
+        assert pydov.hooks[0].count_xml_received == 1
+        assert pydov.hooks[0].count_inject_xml_response == 1
         assert pydov.hooks[0].count_xml_cache_hit == 0
         assert pydov.hooks[0].count_xml_downloaded == 1
+
+        assert pydov.hooks[0].count_meta_received > 0
+        assert pydov.hooks[0].count_inject_meta_response > 0
 
         df = boringsearch.search(
             query=query, return_fields=('pkey_boring', 'mv_mtaw'))
 
         assert pydov.hooks[0].count_wfs_search_init == 2
         assert pydov.hooks[0].count_wfs_search_result == 2
+        assert pydov.hooks[0].count_wfs_search_result_received == 2
+        assert pydov.hooks[0].count_inject_wfs_getfeature_response == 2
+
+        assert pydov.hooks[0].count_xml_received == 2
+        assert pydov.hooks[0].count_inject_xml_response == 2
         assert pydov.hooks[0].count_xml_cache_hit == 0
         assert pydov.hooks[0].count_xml_downloaded == 2
+
+        assert pydov.hooks[0].count_meta_received > 0
+        assert pydov.hooks[0].count_inject_meta_response > 0
 
     @pytest.mark.online
     @pytest.mark.skipif(not service_ok(), reason="DOV service is unreachable")
@@ -188,16 +202,32 @@ class TestHooks(object):
 
         assert pydov.hooks[0].count_wfs_search_init == 1
         assert pydov.hooks[0].count_wfs_search_result == 1
+        assert pydov.hooks[0].count_wfs_search_result_received == 1
+        assert pydov.hooks[0].count_inject_wfs_getfeature_response == 1
+
+        assert pydov.hooks[0].count_xml_received == 1
+        assert pydov.hooks[0].count_inject_xml_response == 1
         assert pydov.hooks[0].count_xml_cache_hit == 0
         assert pydov.hooks[0].count_xml_downloaded == 1
+
+        assert pydov.hooks[0].count_meta_received > 0
+        assert pydov.hooks[0].count_inject_meta_response > 0
 
         df = boringsearch.search(
             query=query, return_fields=('pkey_boring', 'mv_mtaw'))
 
         assert pydov.hooks[0].count_wfs_search_init == 2
         assert pydov.hooks[0].count_wfs_search_result == 2
+        assert pydov.hooks[0].count_wfs_search_result_received == 2
+        assert pydov.hooks[0].count_inject_wfs_getfeature_response == 2
+
+        assert pydov.hooks[0].count_xml_received == 2
+        assert pydov.hooks[0].count_inject_xml_response == 2
         assert pydov.hooks[0].count_xml_cache_hit == 1
         assert pydov.hooks[0].count_xml_downloaded == 1
+
+        assert pydov.hooks[0].count_meta_received > 0
+        assert pydov.hooks[0].count_inject_meta_response > 0
 
     @pytest.mark.online
     @pytest.mark.skipif(not service_ok(), reason="DOV service is unreachable")

--- a/tests/test_util_hooks.py
+++ b/tests/test_util_hooks.py
@@ -191,7 +191,7 @@ class HookInjecter(AbstractHook):
                 '{http://dov.vlaanderen.be/ocdov/dov-pub}gemeente')
             for g in gemeentes:
                 g.text = 'Bevergem'
-            return etree.tostring(tree)
+            return etree.tostring(tree, encoding='utf-8')
 
     def xml_received(self, pkey_object, xml):
         """Save the DOV Xml response in order to adjust and inject later."""
@@ -206,7 +206,7 @@ class HookInjecter(AbstractHook):
                 './/boring/details/boormethode/methode')
             for b in boormethoden:
                 b.text = 'De Pypere 106 T'
-            return etree.tostring(tree)
+            return etree.tostring(tree, encoding='utf-8')
 
 
 class TestHookCount(object):

--- a/tests/test_util_hooks.py
+++ b/tests/test_util_hooks.py
@@ -21,7 +21,6 @@ class HookCounter(AbstractHook):
     def __init__(self):
         self.count_wfs_search_init = 0
         self.count_wfs_search_result = 0
-        self.count_xml_requested = 0
         self.count_xml_cache_hit = 0
         self.count_xml_downloaded = 0
 
@@ -46,19 +45,6 @@ class HookCounter(AbstractHook):
 
         """
         self.count_wfs_search_result += 1
-
-    def xml_requested(self, pkey_object):
-        """Called upon requesting an XML document of an object.
-
-        This is either followed by ``xml_cache_hit`` or ``xml_downloaded``.
-
-        Parameters
-        ----------
-        pkey_object : str
-            Permanent key of the requested object.
-
-        """
-        self.count_xml_requested += 1
 
     def xml_cache_hit(self, pkey_object):
         """Called when the XML document of an object is retrieved from the
@@ -126,7 +112,6 @@ class TestHooks(object):
 
         assert pydov.hooks[0].count_wfs_search_init == 1
         assert pydov.hooks[0].count_wfs_search_result == 1
-        assert pydov.hooks[0].count_xml_requested == 0
         assert pydov.hooks[0].count_xml_cache_hit == 0
         assert pydov.hooks[0].count_xml_downloaded == 0
 
@@ -159,7 +144,6 @@ class TestHooks(object):
 
         assert pydov.hooks[0].count_wfs_search_init == 1
         assert pydov.hooks[0].count_wfs_search_result == 1
-        assert pydov.hooks[0].count_xml_requested == 1
         assert pydov.hooks[0].count_xml_cache_hit == 0
         assert pydov.hooks[0].count_xml_downloaded == 1
 
@@ -168,7 +152,6 @@ class TestHooks(object):
 
         assert pydov.hooks[0].count_wfs_search_init == 2
         assert pydov.hooks[0].count_wfs_search_result == 2
-        assert pydov.hooks[0].count_xml_requested == 2
         assert pydov.hooks[0].count_xml_cache_hit == 0
         assert pydov.hooks[0].count_xml_downloaded == 2
 
@@ -205,7 +188,6 @@ class TestHooks(object):
 
         assert pydov.hooks[0].count_wfs_search_init == 1
         assert pydov.hooks[0].count_wfs_search_result == 1
-        assert pydov.hooks[0].count_xml_requested == 1
         assert pydov.hooks[0].count_xml_cache_hit == 0
         assert pydov.hooks[0].count_xml_downloaded == 1
 
@@ -214,7 +196,6 @@ class TestHooks(object):
 
         assert pydov.hooks[0].count_wfs_search_init == 2
         assert pydov.hooks[0].count_wfs_search_result == 2
-        assert pydov.hooks[0].count_xml_requested == 2
         assert pydov.hooks[0].count_xml_cache_hit == 1
         assert pydov.hooks[0].count_xml_downloaded == 1
 


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

In preparation of the repeatable logging implementation, this PR refactors and extends the hooks system. They are split into two base classes: AbstractReadHook for (safe) read-only hooks and AbstractInjectHook that interferes with pydov's execution stack and should be used in rare cases only.

Some hooks are removed: `xml_requested `is replaced with `xml_received`, while new hooks include:
* `meta_received` and `inject_meta_response`,
* `wfs_search_result_received ` and `inject_wfs_getfeature_response`,
* `xml_received` and `inject_xml_response`.

This allows saving the metadata, wfs and xml results and reinjecting (replaying) them later.

Also centralises hook execution into a common HookRunner class (this is pydov internal code and does not affect hook implementations).
