### PR TITLE
Remove duplicate docstrings and refactor abstract test classes to use class variables

### DIFF
--- a/pydov/search/abstract.py
+++ b/pydov/search/abstract.py
@@ -4,25 +4,17 @@ import datetime
 from distutils.util import strtobool
 
 import owslib
-import pydov
 from owslib.etree import etree
 from owslib.feature import get_schema
-from owslib.fes import (
-    FilterRequest,
-)
+from owslib.fes import FilterRequest
 from owslib.wfs import WebFeatureService
+
+import pydov
 from pydov.util import owsutil
-from pydov.util.dovutil import (
-    get_xsd_schema,
-    build_dov_url,
-)
-from pydov.util.errors import (
-    LayerNotFoundError,
-    InvalidSearchParameterError,
-    FeatureOverflowError,
-    InvalidFieldError,
-    WfsGetFeatureError,
-)
+from pydov.util.dovutil import build_dov_url, get_xsd_schema
+from pydov.util.errors import (FeatureOverflowError, InvalidFieldError,
+                               InvalidSearchParameterError, LayerNotFoundError,
+                               WfsGetFeatureError)
 from pydov.util.hooks import HookRunner
 
 
@@ -63,15 +55,15 @@ class AbstractCommon(object):
                 # Patch for Zulu-time issue of geoserver for WFS 1.1.0
                 if x.endswith('Z'):
                     return datetime.datetime.strptime(x, '%Y-%m-%dZ').date() \
-                           + datetime.timedelta(days=1)
+                        + datetime.timedelta(days=1)
                 else:
                     return datetime.datetime.strptime(x, '%Y-%m-%d').date()
         elif returntype == 'datetime':
             def typeconvert(x):
                 if x.endswith('Z'):
                     return datetime.datetime.strptime(
-                            x, '%Y-%m-%dT%H:%M:%SZ').date() \
-                           + datetime.timedelta(days=1)
+                        x, '%Y-%m-%dT%H:%M:%SZ').date() \
+                        + datetime.timedelta(days=1)
                 else:
                     return datetime.datetime.strptime(
                         x.split('.')[0], '%Y-%m-%dT%H:%M:%S')
@@ -800,5 +792,9 @@ class AbstractSearch(AbstractCommon):
             When the argument supplied as return_fields is not a list,
             tuple or set.
 
+        NotImplementedError
+            This is an abstract method that should be implemented in a
+            subclass.
+
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')

--- a/pydov/search/boring.py
+++ b/pydov/search/boring.py
@@ -3,9 +3,10 @@
 import pandas as pd
 
 from pydov.types.fields import _WfsInjectedField
-from .abstract import AbstractSearch
+
 from ..types.boring import Boring
 from ..util import owsutil
+from .abstract import AbstractSearch
 
 
 class BoringSearch(AbstractSearch):
@@ -31,13 +32,10 @@ class BoringSearch(AbstractSearch):
         super(BoringSearch, self).__init__('dov-pub:Boringen', objecttype)
 
     def _init_namespace(self):
-        """Initialise the WFS namespace associated with the layer."""
         if BoringSearch.__wfs_namespace is None:
             BoringSearch.__wfs_namespace = self._get_namespace()
 
     def _init_fields(self):
-        """Initialise the fields and their metadata available in this search
-        class."""
         if self._fields is None:
             if BoringSearch.__wfs_schema is None:
                 BoringSearch.__wfs_schema = self._get_schema()
@@ -76,60 +74,6 @@ class BoringSearch(AbstractSearch):
 
     def search(self, location=None, query=None,
                sort_by=None, return_fields=None, max_features=None):
-        """Search for boreholes (Boring). Provide `location` and/or `query`
-        and/or `max_features`.
-        When `return_fields` is None, all fields are returned.
-
-        Parameters
-        ----------
-        location : pydov.util.location.AbstractLocationFilter or \
-                    owslib.fes.BinaryLogicOpType<AbstractLocationFilter> or \
-                    owslib.fes.UnaryLogicOpType<AbstractLocationFilter>
-            Location filter limiting the features to retrieve. Can either be a
-            single instance of a subclass of AbstractLocationFilter, or a
-            combination using And, Or, Not of AbstractLocationFilters.
-        query : owslib.fes.OgcExpression
-            OGC filter expression to use for searching. This can contain any
-            combination of filter elements defined in owslib.fes. The query
-            should use the fields provided in `get_fields()`. Note that not
-            all fields are currently supported as a search parameter.
-        sort_by : owslib.fes.SortBy, optional
-            List of properties to sort by.
-        return_fields : list<str> or tuple<str> or set<str>
-            A list of fields to be returned in the output data. This should
-            be a subset of the fields provided in `get_fields()`. Note that
-            not all fields are currently supported as return fields.
-        max_features : int
-            Limit the maximum number of features to request.
-
-        Returns
-        -------
-        pandas.core.frame.DataFrame
-            DataFrame containing the output of the search query.
-
-        Raises
-        ------
-        pydov.util.errors.InvalidSearchParameterError
-            When not one of `location`, `query` or `max_features` is provided.
-
-        pydov.util.errors.InvalidFieldError
-            When at least one of the fields in `return_fields` is unknown.
-
-            When a field that is only accessible as return field is used as
-            a query parameter.
-
-            When a field that can only be used as a query parameter is used as
-            a return field.
-
-        pydov.util.errors.FeatureOverflowError
-            When the number of features to be returned is equal to the
-            maxFeatures limit of the WFS server.
-
-        AttributeError
-            When the argument supplied as return_fields is not a list,
-            tuple or set.
-
-        """
         fts = self._search(location=location, query=query, sort_by=sort_by,
                            return_fields=return_fields,
                            max_features=max_features)

--- a/pydov/search/grondmonster.py
+++ b/pydov/search/grondmonster.py
@@ -33,13 +33,10 @@ class GrondmonsterSearch(AbstractSearch):
             __init__('boringen:grondmonsters', objecttype)
 
     def _init_namespace(self):
-        """Initialise the WFS namespace associated with the layer."""
         if GrondmonsterSearch.__wfs_namespace is None:
             GrondmonsterSearch.__wfs_namespace = self._get_namespace()
 
     def _init_fields(self):
-        """Initialise the fields and their metadata available in this search
-        class."""
         if self._fields is None:
             if GrondmonsterSearch.__wfs_schema is None:
                 GrondmonsterSearch.__wfs_schema = self._get_schema()
@@ -79,60 +76,6 @@ class GrondmonsterSearch(AbstractSearch):
 
     def search(self, location=None, query=None, sort_by=None,
                return_fields=None, max_features=None):
-        """Search for ground samples (Grondmonster). Provide either
-        `location` or `query`. When `return_fields` is None,
-        all fields are returned.
-
-        Parameters
-        ----------
-        location : pydov.util.location.AbstractLocationFilter or \
-                    owslib.fes.BinaryLogicOpType<AbstractLocationFilter> or \
-                    owslib.fes.UnaryLogicOpType<AbstractLocationFilter>
-            Location filter limiting the features to retrieve. Can either be a
-            single instance of a subclass of AbstractLocationFilter, or a
-            combination using And, Or, Not of AbstractLocationFilters.
-        query : owslib.fes.OgcExpression
-            OGC filter expression to use for searching. This can contain any
-            combination of filter elements defined in owslib.fes. The query
-            should use the fields provided in `get_fields()`. Note that not
-            all fields are currently supported as a search parameter.
-        sort_by : owslib.fes.SortBy, optional
-            List of properties to sort by.
-        return_fields : list<str> or tuple<str> or set<str>
-            A list of fields to be returned in the output data. This should
-            be a subset of the fields provided in `get_fields()`. Note that
-            not all fields are currently supported as return fields.
-        max_features : int
-            Limit the maximum number of features to request.
-
-        Returns
-        -------
-        pandas.core.frame.DataFrame
-            DataFrame containing the output of the search query.
-
-        Raises
-        ------
-        pydov.util.errors.InvalidSearchParameterError
-            When not one of `location`, `query` or `max_features` is provided.
-
-        pydov.util.errors.InvalidFieldError
-            When at least one of the fields in `return_fields` is unknown.
-
-            When a field that is only accessible as return field is used as
-            a query parameter.
-
-            When a field that can only be used as a query parameter is used as
-            a return field.
-
-        pydov.util.errors.FeatureOverflowError
-            When the number of features to be returned is equal to the
-            maxFeatures limit of the WFS server.
-
-        AttributeError
-            When the argument supplied as return_fields is not a list,
-            tuple or set.
-
-        """
         self._pre_search_validation(location, query, sort_by, return_fields,
                                     max_features)
 

--- a/pydov/search/grondwaterfilter.py
+++ b/pydov/search/grondwaterfilter.py
@@ -80,10 +80,68 @@ class GrondwaterFilterSearch(AbstractSearch):
 
     def search(self, location=None, query=None, sort_by=None,
                return_fields=None, max_features=None):
-        """Excludes 'empty' filters (i.e. Putten without Filters) by extending
+        """Search for objects of this type. Provide `location` and/or
+        `query` and/or `max_features`.
+        When `return_fields` is None, all fields are returned.
+        
+        Excludes 'empty' filters (i.e. Putten without Filters) by extending
         the `query` with a not-null check on pkey_filter.
+
+        Parameters
+        ----------
+        location : pydov.util.location.AbstractLocationFilter or \
+                   owslib.fes.BinaryLogicOpType<AbstractLocationFilter> or \
+                   owslib.fes.UnaryLogicOpType<AbstractLocationFilter>
+            Location filter limiting the features to retrieve. Can either be a
+            single instance of a subclass of AbstractLocationFilter, or a
+            combination using And, Or, Not of AbstractLocationFilters.
+        query : owslib.fes.OgcExpression
+            OGC filter expression to use for searching. This can contain any
+            combination of filter elements defined in owslib.fes. The query
+            should use the fields provided in `get_fields()`. Note that not
+            all fields are currently supported as a search parameter.
+        sort_by : owslib.fes.SortBy, optional
+            List of properties to sort by.
+        return_fields : list<str> or tuple<str> or set<str>
+            A list of fields to be returned in the output data. This should
+            be a subset of the fields provided in `get_fields()`. Note that
+            not all fields are currently supported as return fields.
+        max_features : int
+            Limit the maximum number of features to request.
+
+        Returns
+        -------
+        pandas.core.frame.DataFrame
+            DataFrame containing the output of the search query.
+
+        Raises
+        ------
+        pydov.util.errors.InvalidSearchParameterError
+            When not one of `location` or `query` or `max_features` is
+            provided.
+
+        pydov.util.errors.InvalidFieldError
+            When at least one of the fields in `return_fields` is unknown.
+
+            When a field that is only accessible as return field is used as
+            a query parameter.
+
+            When a field that can only be used as a query parameter is used as
+            a return field.
+
+        pydov.util.errors.FeatureOverflowError
+            When the number of features to be returned is equal to the
+            maxFeatures limit of the WFS server.
+
+        AttributeError
+            When the argument supplied as return_fields is not a list,
+            tuple or set.
+
+        NotImplementedError
+            This is an abstract method that should be implemented in a
+            subclass.
+
         """
-        GrondwaterFilterSearch.__doc__ += AbstractSearch.__doc__
         self._pre_search_validation(location, query, sort_by, return_fields,
                                     max_features)
 

--- a/pydov/search/grondwaterfilter.py
+++ b/pydov/search/grondwaterfilter.py
@@ -83,7 +83,7 @@ class GrondwaterFilterSearch(AbstractSearch):
         """Search for objects of this type. Provide `location` and/or
         `query` and/or `max_features`.
         When `return_fields` is None, all fields are returned.
-        
+
         Excludes 'empty' filters (i.e. Putten without Filters) by extending
         the `query` with a not-null check on pkey_filter.
 

--- a/pydov/search/grondwaterfilter.py
+++ b/pydov/search/grondwaterfilter.py
@@ -2,16 +2,13 @@
 """Module containing the search classes to retrieve DOV groundwater screen
  data."""
 import pandas as pd
+from owslib.fes import And, Not, PropertyIsNull
 
-from owslib.fes import (
-    Not,
-    PropertyIsNull,
-    And,
-)
 from pydov.types.fields import _WfsInjectedField
-from .abstract import AbstractSearch
+
 from ..types.grondwaterfilter import GrondwaterFilter
 from ..util import owsutil
+from .abstract import AbstractSearch
 
 
 class GrondwaterFilterSearch(AbstractSearch):
@@ -40,13 +37,10 @@ class GrondwaterFilterSearch(AbstractSearch):
               self).__init__('gw_meetnetten:meetnetten', objecttype)
 
     def _init_namespace(self):
-        """Initialise the WFS namespace associated with the layer."""
         if GrondwaterFilterSearch.__wfs_namespace is None:
             GrondwaterFilterSearch.__wfs_namespace = self._get_namespace()
 
     def _init_fields(self):
-        """Initialise the fields and their metadata available in this search
-        class."""
         if self._fields is None:
             if GrondwaterFilterSearch.__wfs_schema is None:
                 GrondwaterFilterSearch.__wfs_schema = self._get_schema()
@@ -86,63 +80,10 @@ class GrondwaterFilterSearch(AbstractSearch):
 
     def search(self, location=None, query=None, sort_by=None,
                return_fields=None, max_features=None):
-        """Search for groundwater screens (GrondwaterFilter). Provide
-        `location` and/or `query` and/or `max_features`.
-        When `return_fields` is None, all fields are returned.
-
-        Excludes 'empty' filters (i.e. Putten without Filters) by extending
+        """Excludes 'empty' filters (i.e. Putten without Filters) by extending
         the `query` with a not-null check on pkey_filter.
-
-        Parameters
-        ----------
-        location : pydov.util.location.AbstractLocationFilter or \
-                    owslib.fes.BinaryLogicOpType<AbstractLocationFilter> or \
-                    owslib.fes.UnaryLogicOpType<AbstractLocationFilter>
-            Location filter limiting the features to retrieve. Can either be a
-            single instance of a subclass of AbstractLocationFilter, or a
-            combination using And, Or, Not of AbstractLocationFilters.
-        query : owslib.fes.OgcExpression
-            OGC filter expression to use for searching. This can contain any
-            combination of filter elements defined in owslib.fes. The query
-            should use the fields provided in `get_fields()`. Note that not
-            all fields are currently supported as a search parameter.
-        sort_by : owslib.fes.SortBy, optional
-            List of properties to sort by.
-        return_fields : list<str> or tuple<str> or set<str>
-            A list of fields to be returned in the output data. This should
-            be a subset of the fields provided in `get_fields()`. Note that
-            not all fields are currently supported as return fields.
-        max_features : int
-            Limit the maximum number of features to request.
-
-        Returns
-        -------
-        pandas.core.frame.DataFrame
-            DataFrame containing the output of the search query.
-
-        Raises
-        ------
-        pydov.util.errors.InvalidSearchParameterError
-            When not one of `location`, `query` or `max_features` is provided.
-
-        pydov.util.errors.InvalidFieldError
-            When at least one of the fields in `return_fields` is unknown.
-
-            When a field that is only accessible as return field is used as
-            a query parameter.
-
-            When a field that can only be used as a query parameter is used as
-            a return field.
-
-        pydov.util.errors.FeatureOverflowError
-            When the number of features to be returned is equal to the
-            maxFeatures limit of the WFS server.
-
-        AttributeError
-            When the argument supplied as return_fields is not a list,
-            tuple or set.
-
         """
+        GrondwaterFilterSearch.__doc__ += AbstractSearch.__doc__
         self._pre_search_validation(location, query, sort_by, return_fields,
                                     max_features)
 

--- a/pydov/search/grondwatermonster.py
+++ b/pydov/search/grondwatermonster.py
@@ -3,9 +3,10 @@
 import pandas as pd
 
 from pydov.types.fields import _WfsInjectedField
-from .abstract import AbstractSearch
+
 from ..types.grondwatermonster import GrondwaterMonster
 from ..util import owsutil
+from .abstract import AbstractSearch
 
 
 class GrondwaterMonsterSearch(AbstractSearch):
@@ -34,13 +35,10 @@ class GrondwaterMonsterSearch(AbstractSearch):
               self).__init__('gw_meetnetten:grondwatermonsters', objecttype)
 
     def _init_namespace(self):
-        """Initialise the WFS namespace associated with the layer."""
         if GrondwaterMonsterSearch.__wfs_namespace is None:
             GrondwaterMonsterSearch.__wfs_namespace = self._get_namespace()
 
     def _init_fields(self):
-        """Initialise the fields and their metadata available in this search
-        class."""
         if self._fields is None:
             if GrondwaterMonsterSearch.__wfs_schema is None:
                 GrondwaterMonsterSearch.__wfs_schema = self._get_schema()
@@ -80,63 +78,6 @@ class GrondwaterMonsterSearch(AbstractSearch):
 
     def search(self, location=None, query=None, sort_by=None,
                return_fields=None, max_features=None):
-        """Search for groundwater samples (GrondwaterMonsterSearch). Provide
-        `location` and/or `query`. When `return_fields` is None,
-        all fields are returned.
-
-        Excludes 'empty' filters (i.e. Putten without Filters) by extending
-        the `query` with a not-null check on pkey_filter.
-
-        Parameters
-        ----------
-        location : pydov.util.location.AbstractLocationFilter or \
-                    owslib.fes.BinaryLogicOpType<AbstractLocationFilter> or \
-                    owslib.fes.UnaryLogicOpType<AbstractLocationFilter>
-            Location filter limiting the features to retrieve. Can either be a
-            single instance of a subclass of AbstractLocationFilter, or a
-            combination using And, Or, Not of AbstractLocationFilters.
-        query : owslib.fes.OgcExpression
-            OGC filter expression to use for searching. This can contain any
-            combination of filter elements defined in owslib.fes. The query
-            should use the fields provided in `get_fields()`. Note that not
-            all fields are currently supported as a search parameter.
-        sort_by : owslib.fes.SortBy, optional
-            List of properties to sort by.
-        return_fields : list<str> or tuple<str> or set<str>
-            A list of fields to be returned in the output data. This should
-            be a subset of the fields provided in `get_fields()`. Note that
-            not all fields are currently supported as return fields.
-        max_features : int
-            Limit the maximum number of features to request.
-
-        Returns
-        -------
-        pandas.core.frame.DataFrame
-            DataFrame containing the output of the search query.
-
-        Raises
-        ------
-        pydov.util.errors.InvalidSearchParameterError
-            When not one of `location` or `query` is provided.
-
-        pydov.util.errors.InvalidFieldError
-            When at least one of the fields in `return_fields` is unknown.
-
-            When a field that is only accessible as return field is used as
-            a query parameter.
-
-            When a field that can only be used as a query parameter is used as
-            a return field.
-
-        pydov.util.errors.FeatureOverflowError
-            When the number of features to be returned is equal to the
-            maxFeatures limit of the WFS server.
-
-        AttributeError
-            When the argument supplied as return_fields is not a list,
-            tuple or set.
-
-        """
         fts = self._search(location=location, query=query, sort_by=sort_by,
                            return_fields=return_fields,
                            max_features=max_features)

--- a/pydov/search/interpretaties.py
+++ b/pydov/search/interpretaties.py
@@ -2,14 +2,14 @@ import pandas as pd
 
 from pydov.search.abstract import AbstractSearch
 from pydov.types.fields import _WfsInjectedField
-from pydov.types.interpretaties import FormeleStratigrafie
-from pydov.types.interpretaties import InformeleHydrogeologischeStratigrafie
-from pydov.types.interpretaties import InformeleStratigrafie
-from pydov.types.interpretaties import HydrogeologischeStratigrafie
-from pydov.types.interpretaties import LithologischeBeschrijvingen
-from pydov.types.interpretaties import GecodeerdeLithologie
-from pydov.types.interpretaties import GeotechnischeCodering
-from pydov.types.interpretaties import QuartairStratigrafie
+from pydov.types.interpretaties import (FormeleStratigrafie,
+                                        GecodeerdeLithologie,
+                                        GeotechnischeCodering,
+                                        HydrogeologischeStratigrafie,
+                                        InformeleHydrogeologischeStratigrafie,
+                                        InformeleStratigrafie,
+                                        LithologischeBeschrijvingen,
+                                        QuartairStratigrafie)
 from pydov.util import owsutil
 
 
@@ -37,13 +37,10 @@ class InformeleStratigrafieSearch(AbstractSearch):
             'interpretaties:informele_stratigrafie', objecttype)
 
     def _init_namespace(self):
-        """Initialise the WFS namespace associated with the layer."""
         if InformeleStratigrafieSearch.__wfs_namespace is None:
             InformeleStratigrafieSearch.__wfs_namespace = self._get_namespace()
 
     def _init_fields(self):
-        """Initialise the fields and their metadata available in this search
-        class."""
         if self._fields is None:
             if InformeleStratigrafieSearch.__wfs_schema is None:
                 InformeleStratigrafieSearch.__wfs_schema = self._get_schema()
@@ -83,60 +80,6 @@ class InformeleStratigrafieSearch(AbstractSearch):
 
     def search(self, location=None, query=None, sort_by=None,
                return_fields=None, max_features=None):
-        """Search for 'informele stratigrafie'. Provide either `location`
-        and/or `query` and/or `max_features`.
-        When `return_fields` is None, all fields are returned.
-
-        Parameters
-        ----------
-        location : pydov.util.location.AbstractLocationFilter or \
-                    owslib.fes.BinaryLogicOpType<AbstractLocationFilter> or \
-                    owslib.fes.UnaryLogicOpType<AbstractLocationFilter>
-            Location filter limiting the features to retrieve. Can either be a
-            single instance of a subclass of AbstractLocationFilter, or a
-            combination using And, Or, Not of AbstractLocationFilters.
-        query : owslib.fes.OgcExpression
-            OGC filter expression to use for searching. This can contain any
-            combination of filter elements defined in owslib.fes. The query
-            should use the fields provided in `get_fields()`. Note that not
-            all fields are currently supported as a search parameter.
-        sort_by : owslib.fes.SortBy, optional
-            List of properties to sort by.
-        return_fields : list<str> or tuple<str> or set<str>
-            A list of fields to be returned in the output data. This should
-            be a subset of the fields provided in `get_fields()`. Note that
-            not all fields are currently supported as return fields.
-        max_features : int
-            Limit the maximum number of features to request.
-
-        Returns
-        -------
-        pandas.core.frame.DataFrame
-            DataFrame containing the output of the search query.
-
-        Raises
-        ------
-        pydov.util.errors.InvalidSearchParameterError
-            When not one of `location`, `query` or `max_features` is provided.
-
-        pydov.util.errors.InvalidFieldError
-            When at least one of the fields in `return_fields` is unknown.
-
-            When a field that is only accessible as return field is used as
-            a query parameter.
-
-            When a field that can only be used as a query parameter is used as
-            a return field.
-
-        pydov.util.errors.FeatureOverflowError
-            When the number of features to be returned is equal to the
-            maxFeatures limit of the WFS server.
-
-        AttributeError
-            When the argument supplied as return_fields is not a list,
-            tuple or set.
-
-        """
         fts = self._search(location=location, query=query, sort_by=sort_by,
                            return_fields=return_fields,
                            extra_wfs_fields=['Type_proef', 'Proeffiche'],
@@ -176,13 +119,10 @@ class FormeleStratigrafieSearch(AbstractSearch):
             'interpretaties:formele_stratigrafie', objecttype)
 
     def _init_namespace(self):
-        """Initialise the WFS namespace associated with the layer."""
         if FormeleStratigrafieSearch.__wfs_namespace is None:
             FormeleStratigrafieSearch.__wfs_namespace = self._get_namespace()
 
     def _init_fields(self):
-        """Initialise the fields and their metadata available in this search
-        class."""
         if self._fields is None:
             if FormeleStratigrafieSearch.__wfs_schema is None:
                 FormeleStratigrafieSearch.__wfs_schema = self._get_schema()
@@ -222,60 +162,6 @@ class FormeleStratigrafieSearch(AbstractSearch):
 
     def search(self, location=None, query=None, sort_by=None,
                return_fields=None, max_features=None):
-        """Search for 'formele stratigrafie'. Provide either `location` and/or
-        `query` and/or `max_features`.
-        When `return_fields` is None, all fields are returned.
-
-        Parameters
-        ----------
-        location : pydov.util.location.AbstractLocationFilter or \
-                    owslib.fes.BinaryLogicOpType<AbstractLocationFilter> or \
-                    owslib.fes.UnaryLogicOpType<AbstractLocationFilter>
-            Location filter limiting the features to retrieve. Can either be a
-            single instance of a subclass of AbstractLocationFilter, or a
-            combination using And, Or, Not of AbstractLocationFilters.
-        query : owslib.fes.OgcExpression
-            OGC filter expression to use for searching. This can contain any
-            combination of filter elements defined in owslib.fes. The query
-            should use the fields provided in `get_fields()`. Note that not
-            all fields are currently supported as a search parameter.
-        sort_by : owslib.fes.SortBy, optional
-            List of properties to sort by.
-        return_fields : list<str> or tuple<str> or set<str>
-            A list of fields to be returned in the output data. This should
-            be a subset of the fields provided in `get_fields()`. Note that
-            not all fields are currently supported as return fields.
-        max_features : int
-            Limit the maximum number of features to request.
-
-        Returns
-        -------
-        pandas.core.frame.DataFrame
-            DataFrame containing the output of the search query.
-
-        Raises
-        ------
-        pydov.util.errors.InvalidSearchParameterError
-            When not one of `location`, `query` or `max_features` is provided.
-
-        pydov.util.errors.InvalidFieldError
-            When at least one of the fields in `return_fields` is unknown.
-
-            When a field that is only accessible as return field is used as
-            a query parameter.
-
-            When a field that can only be used as a query parameter is used as
-            a return field.
-
-        pydov.util.errors.FeatureOverflowError
-            When the number of features to be returned is equal to the
-            maxFeatures limit of the WFS server.
-
-        AttributeError
-            When the argument supplied as return_fields is not a list,
-            tuple or set.
-
-        """
         fts = self._search(location=location, query=query, sort_by=sort_by,
                            return_fields=return_fields,
                            extra_wfs_fields=['Type_proef', 'Proeffiche'],
@@ -315,14 +201,11 @@ class HydrogeologischeStratigrafieSearch(AbstractSearch):
             objecttype)
 
     def _init_namespace(self):
-        """Initialise the WFS namespace associated with the layer."""
         if HydrogeologischeStratigrafieSearch.__wfs_namespace is None:
             HydrogeologischeStratigrafieSearch.__wfs_namespace = \
                 self._get_namespace()
 
     def _init_fields(self):
-        """Initialise the fields and their metadata available in this search
-        class."""
         if self._fields is None:
             if HydrogeologischeStratigrafieSearch.__wfs_schema is None:
                 HydrogeologischeStratigrafieSearch.__wfs_schema = \
@@ -364,61 +247,6 @@ class HydrogeologischeStratigrafieSearch(AbstractSearch):
 
     def search(self, location=None, query=None, sort_by=None,
                return_fields=None, max_features=None):
-        """Search for hydrogeological interpretations. Provide either
-        `location` and/or `query` and/or `max_features`. When
-        `return_fields` is None, all fields
-        are returned.
-
-        Parameters
-        ----------
-        location : pydov.util.location.AbstractLocationFilter or \
-                    owslib.fes.BinaryLogicOpType<AbstractLocationFilter> or \
-                    owslib.fes.UnaryLogicOpType<AbstractLocationFilter>
-            Location filter limiting the features to retrieve. Can either be a
-            single instance of a subclass of AbstractLocationFilter, or a
-            combination using And, Or, Not of AbstractLocationFilters.
-        query : owslib.fes.OgcExpression
-            OGC filter expression to use for searching. This can contain any
-            combination of filter elements defined in owslib.fes. The query
-            should use the fields provided in `get_fields()`. Note that not
-            all fields are currently supported as a search parameter.
-        sort_by : owslib.fes.SortBy, optional
-            List of properties to sort by.
-        return_fields : list<str> or tuple<str> or set<str>
-            A list of fields to be returned in the output data. This should
-            be a subset of the fields provided in `get_fields()`. Note that
-            not all fields are currently supported as return fields.
-        max_features : int
-            Limit the maximum number of features to request.
-
-        Returns
-        -------
-        pandas.core.frame.DataFrame
-            DataFrame containing the output of the search query.
-
-        Raises
-        ------
-        pydov.util.errors.InvalidSearchParameterError
-            When not one of `location`, `query` or `max_features` is provided.
-
-        pydov.util.errors.InvalidFieldError
-            When at least one of the fields in `return_fields` is unknown.
-
-            When a field that is only accessible as return field is used as
-            a query parameter.
-
-            When a field that can only be used as a query parameter is used as
-            a return field.
-
-        pydov.util.errors.FeatureOverflowError
-            When the number of features to be returned is equal to the
-            maxFeatures limit of the WFS server.
-
-        AttributeError
-            When the argument supplied as return_fields is not a list,
-            tuple or set.
-
-        """
         fts = self._search(location=location, query=query, sort_by=sort_by,
                            return_fields=return_fields,
                            max_features=max_features)
@@ -457,14 +285,11 @@ class LithologischeBeschrijvingenSearch(AbstractSearch):
             objecttype)
 
     def _init_namespace(self):
-        """Initialise the WFS namespace associated with the layer."""
         if LithologischeBeschrijvingenSearch.__wfs_namespace is None:
             LithologischeBeschrijvingenSearch.__wfs_namespace = \
                 self._get_namespace()
 
     def _init_fields(self):
-        """Initialise the fields and their metadata available in this search
-        class."""
         if self._fields is None:
             if LithologischeBeschrijvingenSearch.__wfs_schema is None:
                 LithologischeBeschrijvingenSearch.__wfs_schema = \
@@ -506,60 +331,6 @@ class LithologischeBeschrijvingenSearch(AbstractSearch):
 
     def search(self, location=None, query=None, sort_by=None,
                return_fields=None, max_features=None):
-        """Search for 'lithologische beschrijvingen'. Provide either
-        `location` and/or `query` and/or `max_features`.
-        When `return_fields` is None, all fields are returned.
-
-        Parameters
-        ----------
-        location : pydov.util.location.AbstractLocationFilter or \
-                    owslib.fes.BinaryLogicOpType<AbstractLocationFilter> or \
-                    owslib.fes.UnaryLogicOpType<AbstractLocationFilter>
-            Location filter limiting the features to retrieve. Can either be a
-            single instance of a subclass of AbstractLocationFilter, or a
-            combination using And, Or, Not of AbstractLocationFilters.
-        query : owslib.fes.OgcExpression
-            OGC filter expression to use for searching. This can contain any
-            combination of filter elements defined in owslib.fes. The query
-            should use the fields provided in `get_fields()`. Note that not
-            all fields are currently supported as a search parameter.
-        sort_by : owslib.fes.SortBy, optional
-            List of properties to sort by.
-        return_fields : list<str> or tuple<str> or set<str>
-            A list of fields to be returned in the output data. This should
-            be a subset of the fields provided in `get_fields()`. Note that
-            not all fields are currently supported as return fields.
-        max_features : int
-            Limit the maximum number of features to request.
-
-        Returns
-        -------
-        pandas.core.frame.DataFrame
-            DataFrame containing the output of the search query.
-
-        Raises
-        ------
-        pydov.util.errors.InvalidSearchParameterError
-            When not one of `location`, `query` or `max_features` is provided.
-
-        pydov.util.errors.InvalidFieldError
-            When at least one of the fields in `return_fields` is unknown.
-
-            When a field that is only accessible as return field is used as
-            a query parameter.
-
-            When a field that can only be used as a query parameter is used as
-            a return field.
-
-        pydov.util.errors.FeatureOverflowError
-            When the number of features to be returned is equal to the
-            maxFeatures limit of the WFS server.
-
-        AttributeError
-            When the argument supplied as return_fields is not a list,
-            tuple or set.
-
-        """
         fts = self._search(location=location, query=query, sort_by=sort_by,
                            return_fields=return_fields,
                            max_features=max_features)
@@ -598,14 +369,11 @@ class GecodeerdeLithologieSearch(AbstractSearch):
             objecttype)
 
     def _init_namespace(self):
-        """Initialise the WFS namespace associated with the layer."""
         if GecodeerdeLithologieSearch.__wfs_namespace is None:
             GecodeerdeLithologieSearch.__wfs_namespace = \
                 self._get_namespace()
 
     def _init_fields(self):
-        """Initialise the fields and their metadata available in this search
-        class."""
         if self._fields is None:
             if GecodeerdeLithologieSearch.__wfs_schema is None:
                 GecodeerdeLithologieSearch.__wfs_schema = \
@@ -647,60 +415,6 @@ class GecodeerdeLithologieSearch(AbstractSearch):
 
     def search(self, location=None, query=None, sort_by=None,
                return_fields=None, max_features=None):
-        """Search for 'gecodeerde lithologie'. Provide either `location`
-        and/or `query` and/or `max_features`.
-        When `return_fields` is None, all fields are returned.
-
-        Parameters
-        ----------
-        location : pydov.util.location.AbstractLocationFilter or \
-                    owslib.fes.BinaryLogicOpType<AbstractLocationFilter> or \
-                    owslib.fes.UnaryLogicOpType<AbstractLocationFilter>
-            Location filter limiting the features to retrieve. Can either be a
-            single instance of a subclass of AbstractLocationFilter, or a
-            combination using And, Or, Not of AbstractLocationFilters.
-        query : owslib.fes.OgcExpression
-            OGC filter expression to use for searching. This can contain any
-            combination of filter elements defined in owslib.fes. The query
-            should use the fields provided in `get_fields()`. Note that not
-            all fields are currently supported as a search parameter.
-        sort_by : owslib.fes.SortBy, optional
-            List of properties to sort by.
-        return_fields : list<str> or tuple<str> or set<str>
-            A list of fields to be returned in the output data. This should
-            be a subset of the fields provided in `get_fields()`. Note that
-            not all fields are currently supported as return fields.
-        max_features : int
-            Limit the maximum number of features to request.
-
-        Returns
-        -------
-        pandas.core.frame.DataFrame
-            DataFrame containing the output of the search query.
-
-        Raises
-        ------
-        pydov.util.errors.InvalidSearchParameterError
-            When not one of `location`, `query` or `max_features` is provided.
-
-        pydov.util.errors.InvalidFieldError
-            When at least one of the fields in `return_fields` is unknown.
-
-            When a field that is only accessible as return field is used as
-            a query parameter.
-
-            When a field that can only be used as a query parameter is used as
-            a return field.
-
-        pydov.util.errors.FeatureOverflowError
-            When the number of features to be returned is equal to the
-            maxFeatures limit of the WFS server.
-
-        AttributeError
-            When the argument supplied as return_fields is not a list,
-            tuple or set.
-
-        """
         fts = self._search(location=location, query=query, sort_by=sort_by,
                            return_fields=return_fields,
                            max_features=max_features)
@@ -739,14 +453,11 @@ class GeotechnischeCoderingSearch(AbstractSearch):
             objecttype)
 
     def _init_namespace(self):
-        """Initialise the WFS namespace associated with the layer."""
         if GeotechnischeCoderingSearch.__wfs_namespace is None:
             GeotechnischeCoderingSearch.__wfs_namespace = \
                 self._get_namespace()
 
     def _init_fields(self):
-        """Initialise the fields and their metadata available in this search
-        class."""
         if self._fields is None:
             if GeotechnischeCoderingSearch.__wfs_schema is None:
                 GeotechnischeCoderingSearch.__wfs_schema = \
@@ -788,56 +499,6 @@ class GeotechnischeCoderingSearch(AbstractSearch):
 
     def search(self, location=None, query=None, sort_by=None,
                return_fields=None, max_features=None):
-        """Search for 'geotechnische_codering'. Provide either `location`
-        and/or `query` and/or `max_features`.
-        When `return_fields` is None, all fields are returned.
-
-        Parameters
-        ----------
-        location : tuple<minx,miny,maxx,maxy>
-            The bounding box limiting the features to retrieve.
-        query : owslib.fes.OgcExpression
-            OGC filter expression to use for searching. This can contain any
-            combination of filter elements defined in owslib.fes. The query
-            should use the fields provided in `get_fields()`. Note that not
-            all fields are currently supported as a search parameter.
-        sort_by : owslib.fes.SortBy, optional
-            List of properties to sort by.
-        return_fields : list<str> or tuple<str> or set<str>
-            A list of fields to be returned in the output data. This should
-            be a subset of the fields provided in `get_fields()`. Note that
-            not all fields are currently supported as return fields.
-        max_features : int
-            Limit the maximum number of features to request.
-
-        Returns
-        -------
-        pandas.core.frame.DataFrame
-            DataFrame containing the output of the search query.
-
-        Raises
-        ------
-        pydov.util.errors.InvalidSearchParameterError
-            When not one of `location`, `query` or `max_features` is provided.
-
-        pydov.util.errors.InvalidFieldError
-            When at least one of the fields in `return_fields` is unknown.
-
-            When a field that is only accessible as return field is used as
-            a query parameter.
-
-            When a field that can only be used as a query parameter is used as
-            a return field.
-
-        pydov.util.errors.FeatureOverflowError
-            When the number of features to be returned is equal to the
-            maxFeatures limit of the WFS server.
-
-        AttributeError
-            When the argument supplied as return_fields is not a list,
-            tuple or set.
-
-        """
         fts = self._search(location=location, query=query, sort_by=sort_by,
                            return_fields=return_fields,
                            max_features=max_features)
@@ -876,13 +537,10 @@ class QuartairStratigrafieSearch(AbstractSearch):
             'interpretaties:quartaire_stratigrafie', objecttype)
 
     def _init_namespace(self):
-        """Initialise the WFS namespace associated with the layer."""
         if QuartairStratigrafieSearch.__wfs_namespace is None:
             QuartairStratigrafieSearch.__wfs_namespace = self._get_namespace()
 
     def _init_fields(self):
-        """Initialise the fields and their metadata available in this search
-        class."""
         if self._fields is None:
             if QuartairStratigrafieSearch.__wfs_schema is None:
                 QuartairStratigrafieSearch.__wfs_schema = self._get_schema()
@@ -922,61 +580,6 @@ class QuartairStratigrafieSearch(AbstractSearch):
 
     def search(self, location=None, query=None, sort_by=None,
                return_fields=None, max_features=None):
-        """Search for interpretations of Quartair stratigrafie.
-
-        Provide either `location` and/or `query` and/or `max_features`.
-        When `return_fields` is None, all fields are returned.
-
-        Parameters
-        ----------
-        location : pydov.util.location.AbstractLocationFilter or \
-                    owslib.fes.BinaryLogicOpType<AbstractLocationFilter> or \
-                    owslib.fes.UnaryLogicOpType<AbstractLocationFilter>
-            Location filter limiting the features to retrieve. Can either be a
-            single instance of a subclass of AbstractLocationFilter, or a
-            combination using And, Or, Not of AbstractLocationFilters.
-        query : owslib.fes.OgcExpression
-            OGC filter expression to use for searching. This can contain any
-            combination of filter elements defined in owslib.fes. The query
-            should use the fields provided in `get_fields()`. Note that not
-            all fields are currently supported as a search parameter.
-        sort_by : owslib.fes.SortBy, optional
-            List of properties to sort by.
-        return_fields : list<str> or tuple<str> or set<str>
-            A list of fields to be returned in the output data. This should
-            be a subset of the fields provided in `get_fields()`. Note that
-            not all fields are currently supported as return fields.
-        max_features : int
-            Limit the maximum number of features to request.
-
-        Returns
-        -------
-        pandas.core.frame.DataFrame
-            DataFrame containing the output of the search query.
-
-        Raises
-        ------
-        pydov.util.errors.InvalidSearchParameterError
-            When not one of `location`, `query` or `max_features` is provided.
-
-        pydov.util.errors.InvalidFieldError
-            When at least one of the fields in `return_fields` is unknown.
-
-            When a field that is only accessible as return field is used as
-            a query parameter.
-
-            When a field that can only be used as a query parameter is used as
-            a return field.
-
-        pydov.util.errors.FeatureOverflowError
-            When the number of features to be returned is equal to the
-            maxFeatures limit of the WFS server.
-
-        AttributeError
-            When the argument supplied as return_fields is not a list,
-            tuple or set.
-
-        """
         fts = self._search(location=location, query=query, sort_by=sort_by,
                            return_fields=return_fields,
                            max_features=max_features)
@@ -1016,14 +619,11 @@ class InformeleHydrogeologischeStratigrafieSearch(AbstractSearch):
             objecttype)
 
     def _init_namespace(self):
-        """Initialise the WFS namespace associated with the layer."""
         if InformeleHydrogeologischeStratigrafieSearch.__wfs_namespace is None:
             InformeleHydrogeologischeStratigrafieSearch.__wfs_namespace = \
                 self._get_namespace()
 
     def _init_fields(self):
-        """Initialise the fields and their metadata available in this search
-        class."""
         if self._fields is None:
             if InformeleHydrogeologischeStratigrafieSearch.__wfs_schema is \
                     None:
@@ -1071,59 +671,6 @@ class InformeleHydrogeologischeStratigrafieSearch(AbstractSearch):
 
     def search(self, location=None, query=None, sort_by=None,
                return_fields=None, max_features=None):
-        """Search for boreholes (Boring). Provide either `location` or `query`.
-        When `return_fields` is None, all fields are returned.
-
-        Parameters
-        ----------
-        location : pydov.util.location.AbstractLocationFilter or \
-                    owslib.fes.BinaryLogicOpType<AbstractLocationFilter> or \
-                    owslib.fes.UnaryLogicOpType<AbstractLocationFilter>
-            Location filter limiting the features to retrieve. Can either be a
-            single instance of a subclass of AbstractLocationFilter, or a
-            combination using And, Or, Not of AbstractLocationFilters.
-        query : owslib.fes.OgcExpression
-            OGC filter expression to use for searching. This can contain any
-            combination of filter elements defined in owslib.fes. The query
-            should use the fields provided in `get_fields()`. Note that not
-            all fields are currently supported as a search parameter.
-        sort_by : owslib.fes.SortBy, optional
-            List of properties to sort by.
-        return_fields : list<str> or tuple<str> or set<str>
-            A list of fields to be returned in the output data. This should
-            be a subset of the fields provided in `get_fields()`. Note that
-            not all fields are currently supported as return fields.
-        max_features : int
-            Limit the maximum number of features to request.
-
-        Returns
-        -------
-        pandas.core.frame.DataFrame
-            DataFrame containing the output of the search query.
-
-        Raises
-        ------
-        pydov.util.errors.InvalidSearchParameterError
-            When not one of `location` or `query` is provided.
-
-        pydov.util.errors.InvalidFieldError
-            When at least one of the fields in `return_fields` is unknown.
-
-            When a field that is only accessible as return field is used as
-            a query parameter.
-
-            When a field that can only be used as a query parameter is used as
-            a return field.
-
-        pydov.util.errors.FeatureOverflowError
-            When the number of features to be returned is equal to the
-            maxFeatures limit of the WFS server.
-
-        AttributeError
-            When the argument supplied as return_fields is not a list,
-            tuple or set.
-
-        """
         fts = self._search(location=location, query=query, sort_by=sort_by,
                            return_fields=return_fields,
                            max_features=max_features)

--- a/pydov/search/sondering.py
+++ b/pydov/search/sondering.py
@@ -33,13 +33,10 @@ class SonderingSearch(AbstractSearch):
             'dov-pub:Sonderingen', objecttype)
 
     def _init_namespace(self):
-        """Initialise the WFS namespace associated with the layer."""
         if SonderingSearch.__wfs_namespace is None:
             SonderingSearch.__wfs_namespace = self._get_namespace()
 
     def _init_fields(self):
-        """Initialise the fields and their metadata available in this search
-        class."""
         if self._fields is None:
             if SonderingSearch.__wfs_schema is None:
                 SonderingSearch.__wfs_schema = self._get_schema()
@@ -78,60 +75,6 @@ class SonderingSearch(AbstractSearch):
 
     def search(self, location=None, query=None, sort_by=None,
                return_fields=None, max_features=None):
-        """Search for CPT measurements (Sondering). Provide `location` and/or
-        `query` and/or `max_features`.
-        When `return_fields` is None, all fields are returned.
-
-        Parameters
-        ----------
-        location : pydov.util.location.AbstractLocationFilter or \
-                    owslib.fes.BinaryLogicOpType<AbstractLocationFilter> or \
-                    owslib.fes.UnaryLogicOpType<AbstractLocationFilter>
-            Location filter limiting the features to retrieve. Can either be a
-            single instance of a subclass of AbstractLocationFilter, or a
-            combination using And, Or, Not of AbstractLocationFilters.
-        query : owslib.fes.OgcExpression
-            OGC filter expression to use for searching. This can contain any
-            combination of filter elements defined in owslib.fes. The query
-            should use the fields provided in `get_fields()`. Note that not
-            all fields are currently supported as a search parameter.
-        sort_by : owslib.fes.SortBy, optional
-            List of properties to sort by.
-        return_fields : list<str> or tuple<str> or set<str>
-            A list of fields to be returned in the output data. This should
-            be a subset of the fields provided in `get_fields()`. Note that
-            not all fields are currently supported as return fields.
-        max_features : int
-            Limit the maximum number of features to request.
-
-        Returns
-        -------
-        pandas.core.frame.DataFrame
-            DataFrame containing the output of the search query.
-
-        Raises
-        ------
-        pydov.util.errors.InvalidSearchParameterError
-            When not one of `location`, `query` or `max_features` is provided.
-
-        pydov.util.errors.InvalidFieldError
-            When at least one of the fields in `return_fields` is unknown.
-
-            When a field that is only accessible as return field is used as
-            a query parameter.
-
-            When a field that can only be used as a query parameter is used as
-            a return field.
-
-        pydov.util.errors.FeatureOverflowError
-            When the number of features to be returned is equal to the
-            maxFeatures limit of the WFS server.
-
-        AttributeError
-            When the argument supplied as return_fields is not a list,
-            tuple or set.
-
-        """
         fts = self._search(location=location, query=query, sort_by=sort_by,
                            return_fields=return_fields,
                            max_features=max_features)

--- a/pydov/types/abstract.py
+++ b/pydov/types/abstract.py
@@ -6,22 +6,15 @@ import warnings
 from collections import OrderedDict
 from multiprocessing.dummy import Pool
 
-import pydov
 import numpy as np
-
 from owslib.etree import etree
+
+import pydov
 from pydov.search.abstract import AbstractCommon
 from pydov.types.fields import AbstractField
-from pydov.util.dovutil import (
-    get_dov_xml,
-    parse_dov_xml,
-)
+from pydov.util.dovutil import get_dov_xml, parse_dov_xml
 
-from ..util.errors import (
-    InvalidFieldError,
-    XmlParseError,
-    XmlParseWarning,
-)
+from ..util.errors import InvalidFieldError, XmlParseError, XmlParseWarning
 from ..util.hooks import HookRunner
 
 
@@ -343,7 +336,7 @@ class AbstractDovType(AbstractTypeCommon):
             self._parse_subtypes(xml)
         except XmlParseError:
             warnings.warn(("Failed to parse XML for object '{}'. Resulting "
-                          "dataframe will be incomplete.").format(self.pkey),
+                           "dataframe will be incomplete.").format(self.pkey),
                           XmlParseWarning)
 
     @classmethod
@@ -356,6 +349,12 @@ class AbstractDovType(AbstractTypeCommon):
             XML element representing a single record of the WFS layer.
         namespace : str
             Namespace associated with this WFS featuretype.
+
+        Returns
+        -------
+        cls
+            An instance of this class populated with the data from the WFS
+            element.
 
         Raises
         ------

--- a/pydov/types/boring.py
+++ b/pydov/types/boring.py
@@ -1,14 +1,9 @@
 # -*- coding: utf-8 -*-
 """Module containing the DOV data type for boreholes (Boring), including
 subtypes."""
-from pydov.types.fields import (
-    XmlField,
-    WfsField,
-)
-from .abstract import (
-    AbstractDovType,
-    AbstractDovSubType,
-)
+from pydov.types.fields import WfsField, XmlField
+
+from .abstract import AbstractDovSubType, AbstractDovType
 
 
 class BoorMethode(AbstractDovSubType):
@@ -83,22 +78,6 @@ class Boring(AbstractDovType):
 
     @classmethod
     def from_wfs_element(cls, feature, namespace):
-        """Build `Boring` instance from a WFS feature element.
-
-        Parameters
-        ----------
-        feature : etree.Element
-            XML element representing a single record of the WFS layer.
-        namespace : str
-            Namespace associated with this WFS featuretype.
-
-        Returns
-        -------
-        boring : Boring
-            An instance of this class populated with the data from the WFS
-            element.
-
-        """
         b = cls(feature.findtext('./{{{}}}fiche'.format(namespace)))
 
         for field in cls.get_fields(source=('wfs',)).values():

--- a/pydov/types/grondmonster.py
+++ b/pydov/types/grondmonster.py
@@ -1,15 +1,9 @@
 # -*- coding: utf-8 -*-
 """Module containing the DOV data type for grondmonster, including
 subtypes."""
-from .abstract import (
-    AbstractDovType,
-    AbstractDovSubType,
-)
-from pydov.types.fields import (
-    WfsField,
-    XmlField,
-    XsdType,
-)
+from pydov.types.fields import WfsField, XmlField, XsdType
+
+from .abstract import AbstractDovSubType, AbstractDovType
 
 
 class Korrelverdeling(AbstractDovSubType):
@@ -153,22 +147,6 @@ class Grondmonster(AbstractDovType):
 
     @classmethod
     def from_wfs_element(cls, feature, namespace):
-        """Build `Grondmonster` instance from a WFS feature element.
-
-        Parameters
-        ----------
-        feature : etree.Element
-            XML element representing a single record of the WFS layer.
-        namespace : str
-            Namespace associated with this WFS featuretype.
-
-        Returns
-        -------
-        grondmonster : Grondmonster
-            An instance of this class populated with the data from the WFS
-            element.
-
-        """
         grondmonster = cls(feature.findtext(
             './{{{}}}grondmonsterfiche'.format(namespace)))
 

--- a/pydov/types/grondwaterfilter.py
+++ b/pydov/types/grondwaterfilter.py
@@ -1,16 +1,10 @@
 # -*- coding: utf-8 -*-
 """Module containing the DOV data type for screens (Filter), including
 subtypes."""
-from pydov.types.fields import (
-    XmlField,
-    XsdType,
-    WfsField,
-)
+from pydov.types.fields import WfsField, XmlField, XsdType
 from pydov.util.dovutil import build_dov_url
-from .abstract import (
-    AbstractDovType,
-    AbstractDovSubType,
-)
+
+from .abstract import AbstractDovSubType, AbstractDovType
 
 _filterDataCodes_xsd = build_dov_url(
     'xdov/schema/latest/xsd/kern/gwmeetnet/FilterDataCodes.xsd')
@@ -139,22 +133,6 @@ class GrondwaterFilter(AbstractDovType):
 
     @classmethod
     def from_wfs_element(cls, feature, namespace):
-        """Build `GrondwaterFilter` instance from a WFS feature element.
-
-        Parameters
-        ----------
-        feature : etree.Element
-            XML element representing a single record of the WFS layer.
-        namespace : str
-            Namespace associated with this WFS featuretype.
-
-        Returns
-        -------
-        filter : GrondwaterFilter
-            An instance of this class populated with the data from the WFS
-            element.
-
-        """
         gwfilter = cls(
             feature.findtext('./{{{}}}filterfiche'.format(namespace)))
 

--- a/pydov/types/grondwatermonster.py
+++ b/pydov/types/grondwatermonster.py
@@ -1,15 +1,9 @@
 # -*- coding: utf-8 -*-
 """Module containing the DOV data type for groundwater samples
 (GrondwaterMonsters), including subtypes."""
-from pydov.types.fields import (
-    XmlField,
-    XsdType,
-    WfsField,
-)
-from .abstract import (
-    AbstractDovType,
-    AbstractDovSubType,
-)
+from pydov.types.fields import WfsField, XmlField, XsdType
+
+from .abstract import AbstractDovSubType, AbstractDovType
 
 _observatieDataCodes_xsd = 'https://www.dov.vlaanderen.be/xdov/schema/' \
                        'latest/xsd/kern/observatie/ObservatieDataCodes.xsd'
@@ -97,22 +91,6 @@ class GrondwaterMonster(AbstractDovType):
 
     @classmethod
     def from_wfs_element(cls, feature, namespace):
-        """Build `GrondwaterMonster` instance from a WFS feature element.
-
-        Parameters
-        ----------
-        feature : etree.Element
-            XML element representing a single record of the WFS layer.
-        namespace : str
-            Namespace associated with this WFS featuretype.
-
-        Returns
-        -------
-        gwmonster : GrondwaterMonster
-            An instance of this class populated with the data from the WFS
-            element.
-
-        """
         gwmonster = cls(
             feature.findtext(
                 './{{{}}}grondwatermonsterfiche'.format(namespace)))

--- a/pydov/types/interpretaties.py
+++ b/pydov/types/interpretaties.py
@@ -3,16 +3,8 @@
 subtypes."""
 import numpy as np
 
-from pydov.types.abstract import (
-    AbstractDovType,
-    AbstractDovSubType,
-)
-from pydov.types.fields import (
-    WfsField,
-    _CustomField,
-    XmlField,
-    XsdType,
-)
+from pydov.types.abstract import AbstractDovSubType, AbstractDovType
+from pydov.types.fields import WfsField, XmlField, XsdType, _CustomField
 from pydov.util.dovutil import build_dov_url
 
 
@@ -57,22 +49,6 @@ class AbstractCommonInterpretatie(AbstractDovType):
 
     @classmethod
     def from_wfs_element(cls, feature, namespace):
-        """Build an instance from a WFS feature element.
-
-        Parameters
-        ----------
-        feature : etree.Element
-            XML element representing a single record of the WFS layer.
-        namespace : str
-            Namespace associated with this WFS featuretype.
-
-        Returns
-        -------
-        instance of this class
-            An instance of this class populated with the data from the WFS
-            element.
-
-        """
         instance = cls(
             feature.findtext('./{{{}}}Interpretatiefiche'.format(namespace)))
 
@@ -148,22 +124,6 @@ class AbstractBoringInterpretatie(AbstractDovType):
 
     @classmethod
     def from_wfs_element(cls, feature, namespace):
-        """Build an instance from a WFS feature element.
-
-        Parameters
-        ----------
-        feature : etree.Element
-            XML element representing a single record of the WFS layer.
-        namespace : str
-            Namespace associated with this WFS featuretype.
-
-        Returns
-        -------
-        instance of this class
-            An instance of this class populated with the data from the WFS
-            element.
-
-        """
         instance = cls(
             feature.findtext('./{{{}}}Interpretatiefiche'.format(namespace)))
 
@@ -516,12 +476,7 @@ class GeotechnischeCoderingLaag(AbstractDovSubType):
 
 class GeotechnischeCodering(AbstractBoringInterpretatie):
     """Class representing the DOV data type for 'geotechnische
-    codering' interpretations.
-
-    In Dutch: Een geotechnische codering van een boring is een
-    codering opgesteld vanuit geotechnisch oogpunt,
-    rekening houdend met informatie uit de lithologie,
-    laboproeven en bijhorende sondering(en)."""
+    codering' interpretations."""
 
     subtypes = [GeotechnischeCoderingLaag]
 
@@ -576,16 +531,7 @@ class QuartairStratigrafieLaag(AbstractDovSubType):
 
 class QuartairStratigrafie(AbstractBoringInterpretatie):
     """Class representing the DOV data type for 'Quartairstratigrafie'
-    interpretations.
-
-    In Dutch: Afgeleid type van interpretatie, specifiek voor de quartair-
-    stratigrafie. Een Quartair interpretatie omvat een discrete formele
-    interpretatie van het materiaal in de ondergrond, al dan niet aan
-    de hand van monsters, op basis van een door DOV gestandaardiseerde
-    codering. De Quartair interpretatie gebeurt in tegenstelling tot de
-    formele interpretatie op basis van sedimentgenetische profieltypen
-    ipv lithostratigrafie
-    """
+    interpretations."""
 
     subtypes = [QuartairStratigrafieLaag]
 

--- a/pydov/types/sondering.py
+++ b/pydov/types/sondering.py
@@ -1,14 +1,8 @@
 # -*- coding: utf-8 -*-
 """Module containing the DOV data type for CPT measurements (Sonderingen),
 including subtypes."""
-from pydov.types.abstract import (
-    AbstractDovType,
-    AbstractDovSubType,
-)
-from pydov.types.fields import (
-    XmlField,
-    WfsField,
-)
+from pydov.types.abstract import AbstractDovSubType, AbstractDovType
+from pydov.types.fields import WfsField, XmlField
 
 
 class Meetdata(AbstractDovSubType):
@@ -103,22 +97,6 @@ class Sondering(AbstractDovType):
 
     @classmethod
     def from_wfs_element(cls, feature, namespace):
-        """Build `Sondering` instance from a WFS feature element.
-
-        Parameters
-        ----------
-        feature : etree.Element
-            XML element representing a single record of the WFS layer.
-        namespace : str
-            Namespace associated with this WFS featuretype.
-
-        Returns
-        -------
-        sondering : Sondering
-            An instance of this class populated with the data from the WFS
-            element.
-
-        """
         s = cls(feature.findtext('./{{{}}}fiche'.format(namespace)))
 
         for field in cls.get_fields(source=('wfs',)).values():

--- a/pydov/util/caching.py
+++ b/pydov/util/caching.py
@@ -65,7 +65,7 @@ class AbstractCache(object):
             The raw XML data of this DOV object as bytes.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def clean(self):
         """Clean the cache by removing old records from the cache.
@@ -76,11 +76,11 @@ class AbstractCache(object):
         the maximum age from the cache.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def remove(self):
         """Remove the entire cache."""
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
 
 class AbstractFileCache(AbstractCache):
@@ -139,7 +139,7 @@ class AbstractFileCache(AbstractCache):
             Full absolute path on disk where the object is to be saved.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def _get_type_key_from_url(self, url):
         """Parse a DOV permalink and return the datatype and object key.
@@ -179,7 +179,7 @@ class AbstractFileCache(AbstractCache):
             referred to by the URL.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def _is_valid(self, datatype, key):
         """Check if a valid version of the given DOV object exists in the
@@ -228,7 +228,7 @@ class AbstractFileCache(AbstractCache):
             XML string of the DOV object, loaded from the cache.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def _save(self, datatype, key, content):
         """Save the given content in the cache.
@@ -243,26 +243,9 @@ class AbstractFileCache(AbstractCache):
             The raw XML data of this DOV object as bytes.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get(self, url):
-        """Get the XML data for the DOV object referenced by the given URL.
-
-        If a valid version exists in the cache, it will be loaded and
-        returned. If no valid version exists, the XML will be downloaded
-        from the DOV webservice, saved in the cache and returned.
-
-        Parameters
-        ----------
-        url : str
-            Permanent URL to a DOV object.
-
-        Returns
-        -------
-        xml : bytes
-            The raw XML data of this DOV object as bytes.
-
-        """
         datatype, key = self._get_type_key_from_url(url)
 
         data = HookRunner.execute_inject_xml_response(url)
@@ -330,58 +313,14 @@ class PlainTextFileCache(AbstractFileCache):
     """Class for plain text caching of downloaded XML files from DOV."""
 
     def _get_filepath(self, datatype, key):
-        """Get the location on disk where the object with given datatype and
-        key is to be saved.
-
-        Parameters
-        ----------
-        datatype : str
-            Datatype of the DOV object.
-        key : str
-            Unique and permanent object key of the DOV object.
-
-        Returns
-        -------
-        str
-            Full absolute path on disk where the object is to be saved.
-
-        """
         return os.path.join(self.cachedir, datatype, key + '.xml')
 
     def _get_type_key_from_path(self, path):
-        """Parse a filepath and return the datatype and object key.
-
-        Parameters
-        ----------
-        path : str
-            Full, absolute, path to a cached file.
-
-        Returns
-        -------
-        datatype : str
-            Datatype of the DOV object referred to by the URL.
-        key : str
-            Unique and permanent key of the instance of the DOV object
-            referred to by the URL.
-
-        """
         key = os.path.basename(path).rstrip('.xml')
         datatype = os.path.dirname(path).split()[-1]
         return datatype, key
 
     def _save(self, datatype, key, content):
-        """Save the given content in the cache.
-
-        Parameters
-        ----------
-        datatype : str
-            Datatype of the DOV object to save.
-        key : str
-            Unique and permanent object key of the DOV object to save.
-        content : bytes
-            The raw XML data of this DOV object as bytes.
-
-        """
         filepath = self._get_filepath(datatype, key)
         folder = os.path.dirname(filepath)
 
@@ -392,19 +331,6 @@ class PlainTextFileCache(AbstractFileCache):
             f.write(content.decode('utf-8'))
 
     def _load(self, datatype, key):
-        """Read a cached version from disk.
-
-        datatype : str
-            Datatype of the DOV object.
-        key : str
-            Unique and permanent object key of the DOV object.
-
-        Returns
-        -------
-        str (xml)
-            XML string of the DOV object, loaded from the cache.
-
-        """
         filepath = self._get_filepath(datatype, key)
         with open(filepath, 'r', encoding='utf-8') as f:
             return f.read()
@@ -414,58 +340,14 @@ class GzipTextFileCache(AbstractFileCache):
     """Class for GZipped text caching of downloaded XML files from DOV."""
 
     def _get_filepath(self, datatype, key):
-        """Get the location on disk where the object with given datatype and
-        key is to be saved.
-
-        Parameters
-        ----------
-        datatype : str
-            Datatype of the DOV object.
-        key : str
-            Unique and permanent object key of the DOV object.
-
-        Returns
-        -------
-        str
-            Full absolute path on disk where the object is to be saved.
-
-        """
         return os.path.join(self.cachedir, datatype, key + '.xml.gz')
 
     def _get_type_key_from_path(self, path):
-        """Parse a filepath and return the datatype and object key.
-
-        Parameters
-        ----------
-        path : str
-            Full, absolute, path to a cached file.
-
-        Returns
-        -------
-        datatype : str
-            Datatype of the DOV object referred to by the URL.
-        key : str
-            Unique and permanent key of the instance of the DOV object
-            referred to by the URL.
-
-        """
         key = os.path.basename(path).rstrip('.xml.gz')
         datatype = os.path.dirname(path).split()[-1]
         return datatype, key
 
     def _save(self, datatype, key, content):
-        """Save the given content in the cache.
-
-        Parameters
-        ----------
-        datatype : str
-            Datatype of the DOV object to save.
-        key : str
-            Unique and permanent object key of the DOV object to save.
-        content : bytes
-            The raw XML data of this DOV object as bytes.
-
-        """
         filepath = self._get_filepath(datatype, key)
         folder = os.path.dirname(filepath)
 
@@ -476,19 +358,6 @@ class GzipTextFileCache(AbstractFileCache):
             f.write(content)
 
     def _load(self, datatype, key):
-        """Read a cached version from disk.
-
-        datatype : str
-            Datatype of the DOV object.
-        key : str
-            Unique and permanent object key of the DOV object.
-
-        Returns
-        -------
-        str (xml)
-            XML string of the DOV object, loaded from the cache.
-
-        """
         filepath = self._get_filepath(datatype, key)
         with gzip.open(filepath, 'rb') as f:
             return f.read().decode('utf-8')

--- a/pydov/util/location.py
+++ b/pydov/util/location.py
@@ -8,9 +8,7 @@ Filter Encoding 1.1 and GML 3.1.1.
 import os
 
 from owslib.etree import etree
-from owslib.fes import (
-    Or,
-)
+from owslib.fes import Or
 
 
 class AbstractLocation(object):
@@ -33,7 +31,7 @@ class AbstractLocation(object):
         etree.Element
             XML element of the GML representation of this location.
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
 
 class AbstractLocationFilter(object):
@@ -60,7 +58,7 @@ class AbstractLocationFilter(object):
             The name of the geometry column to query.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def toXML(self):
         """Return the XML representation of the location filter.
@@ -81,7 +79,7 @@ class AbstractLocationFilter(object):
             filters without the geometry column name are invalid.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
 
 class AbstractBinarySpatialFilter(AbstractLocationFilter):
@@ -101,7 +99,7 @@ class AbstractBinarySpatialFilter(AbstractLocationFilter):
             Type of this filter: one of Equals, Disjoint, Touches, Within,
             Overlaps, Crosses, Intersects or Contains.
         location : AbstractLocation
-            An instance of a location to use as location for the Within
+            An instance of a location to use as location for the spatial
             filter.
 
         """
@@ -118,33 +116,11 @@ class AbstractBinarySpatialFilter(AbstractLocationFilter):
         self.element.append(location.get_element())
 
     def set_geometry_column(self, geometry_column):
-        """Set the name of the geometry column to query.
-
-        Parameters
-        ----------
-        geometry_column : str
-            The name of the geometry column to query.
-
-        """
         self.geom_column = geometry_column
         geom = self.element.find('.//{http://www.opengis.net/ogc}PropertyName')
         geom.text = geometry_column
 
     def toXML(self):
-        """Return the XML representation of the Within filter.
-
-        Returns
-        -------
-        etree.Element
-            XML element of this Within filter.
-
-        Raises
-        ------
-        RuntimeError
-            When called before the geometry column name is set: location
-            filters without the geometry column name are invalid.
-
-        """
         if self.geom_column == '':
             raise RuntimeError('Geometry column has not been set. Use '
                                '"set_geometry_column" to set it.')
@@ -209,14 +185,6 @@ class Box(AbstractLocation):
         self.element.append(upper_corner)
 
     def get_element(self):
-        """Return the GML representation of the box.
-
-        Returns
-        -------
-        etree.Element
-            XML element of the GML representation of this box.
-
-        """
         return self.element
 
 
@@ -254,13 +222,6 @@ class Point(AbstractLocation):
         self.element.append(coordinates)
 
     def get_element(self):
-        """Return the GML representation of the point.
-
-        Returns
-        -------
-        etree.Element
-            XML element of the GML representation of this point.
-        """
         return self.element
 
 
@@ -288,13 +249,6 @@ class GmlObject(AbstractLocation):
             self.element = gml_element
 
     def get_element(self):
-        """Return the GML representation of this location.
-
-        Returns
-        -------
-        etree.Element
-            XML element of the GML representation of this location.
-        """
         return self.element
 
 
@@ -441,33 +395,11 @@ class WithinDistance(AbstractLocationFilter):
         self.element.append(distance)
 
     def set_geometry_column(self, geometry_column):
-        """Set the name of the geometry column to query.
-
-        Parameters
-        ----------
-        geometry_column : str
-            The name of the geometry column to query.
-
-        """
         self.geom_column = geometry_column
         geom = self.element.find('.//{http://www.opengis.net/ogc}PropertyName')
         geom.text = geometry_column
 
     def toXML(self):
-        """Return the XML representation of the WithinDistance filter.
-
-        Returns
-        -------
-        etree.Element
-            XML element of this WithinDistance filter.
-
-        Raises
-        ------
-        RuntimeError
-            When called before the geometry column name is set: location
-            filters without the geometry column name are invalid.
-
-        """
         if self.geom_column == '':
             raise RuntimeError('Geometry column has not been set. Use '
                                '"set_geometry_column" to set it.')
@@ -622,14 +554,6 @@ class GmlFilter(AbstractLocationFilter):
             raise ValueError('Failed to extract geometries from GML file.')
 
     def set_geometry_column(self, geometry_column):
-        """Set the name of the geometry column to query.
-
-        Parameters
-        ----------
-        geometry_column : str
-            The name of the geometry column to query.
-
-        """
         if len(self.subelements) == 1:
             self.element.set_geometry_column(geometry_column)
         else:
@@ -637,18 +561,4 @@ class GmlFilter(AbstractLocationFilter):
                 sub_element.set_geometry_column(geometry_column)
 
     def toXML(self):
-        """Return the XML representation of the GML filter.
-
-        Returns
-        -------
-        etree.Element
-            XML element of this GML filter.
-
-        Raises
-        ------
-        RuntimeError
-            When called before the geometry column name is set: location
-            filters without the geometry column name are invalid.
-
-        """
         return self.element.toXML()

--- a/tests/abstract.py
+++ b/tests/abstract.py
@@ -115,7 +115,7 @@ class AbstractTestSearch(object):
     df_default_columns : list of str
             A list of the column names of the default dataframe.
 
-        """
+    """
 
     def test_pluggable_type(self):
         """Test whether the search object can be initialised by explicitly
@@ -616,109 +616,36 @@ class AbstractTestSearch(object):
 
 
 class AbstractTestTypes(object):
-    """Class grouping common test code for datatype classes."""
-    def get_type(self):
-        """Get the class reference for this datatype.
+    """Class grouping common test code for datatype classes.
 
-        Returns
-        -------
-        pydov.types.abstract.AbstractDovType
-            Class reference for the corresponding datatype.
+    Subclasses should implement at least the following public attributes
+    in order for the tests defined here to be executed.
 
-        """
-        raise NotImplementedError('This should be implemented in a subclass.')
-
-    def get_namespace(self):
-        """Get the WFS namespace associated with this datatype.
-
-        Returns
-        -------
-        str
-            WFS namespace for this type.
-
-        """
-        raise NotImplementedError('This should be implemented in a subclass.')
-
-    def get_pkey_base(self):
-        """Get the base URL for the permanent keys of this datatype.
-
-        Returns
-        -------
-        str
-            Base URL for the permanent keys of this datatype. For example
-            "https://www.dov.vlaanderen.be/data/boring/"
-
-        """
-        raise NotImplementedError('This should be implemented in a subclass.')
-
-    def get_field_names(self):
-        """Get the field names for this type as listed in the documentation in
+    Attributes
+    ----------
+    datatype_class : pydov.types.abstract.AbstractDovType
+        Class reference for the corresponding datatype.
+    namespace : str
+        WFS namespace for this type.
+    pkey_base : str
+        Base URL for the permanent keys of this datatype.
+    field_names : list of str
+        The field names for this type as listed in the documentation in
         docs/description_output_dataframes.rst
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
-        raise NotImplementedError('This should be implemented in a subclass.')
-
-    def get_field_names_subtypes(self):
-        """Get the field names of this type that originate from subtypes only.
-
-        Returns
-        -------
-        list<str>
-            List of field names from subtypes.
-
-        """
-        raise NotImplementedError('This should be implemented in a subclass.')
-
-    def get_field_names_nosubtypes(self):
-        """Get the field names for this type, without including fields from
+    field_names_subtypes : list of str
+        The field names of this type that originate from subtypes only.
+    field_names_nosubtypes : list of str
+        The field names for this type, without including fields from
         subtypes.
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
-        raise NotImplementedError('This should be implemented in a subclass.')
-
-    def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
-        raise NotImplementedError('This should be implemented in a subclass.')
-
-    def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
+    valid_returnfields : tuple of str
+        A tuple of valid return fields from the main type.
+    valid_returnfields_subtype : typle of str
             A tuple containing valid return fields, including fields from a
             subtype.
-
-        """
-        raise NotImplementedError('This should be implemented in a subclass.')
-
-    def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
+    inexistent_field : str
             The name of an inexistent field.
 
-        """
-        raise NotImplementedError('This should be implemented in a subclass.')
+    """
 
     def test_get_field_names(self):
         """Test the get_field_names method.
@@ -727,8 +654,8 @@ class AbstractTestTypes(object):
         ones we list in docs/description_output_dataframes.rst.
 
         """
-        fields = self.get_type().get_field_names()
-        assert fields == self.get_field_names()
+        fields = self.datatype_class.get_field_names()
+        assert fields == self.field_names
 
     def test_get_field_names_nosubtypes(self):
         """Test the get_field_names method without including subtypes.
@@ -737,10 +664,10 @@ class AbstractTestTypes(object):
         disabling subtypes.
 
         """
-        fields = self.get_type().get_field_names(
+        fields = self.datatype_class.get_field_names(
             return_fields=None, include_subtypes=False)
 
-        assert fields == self.get_field_names_nosubtypes()
+        assert fields == self.field_names_nosubtypes
 
     def test_get_field_names_returnfields_nosubtypes(self):
         """Test the get_field_names method when specifying return
@@ -750,11 +677,11 @@ class AbstractTestTypes(object):
         fields.
 
         """
-        fields = self.get_type().get_field_names(
-            return_fields=self.get_valid_returnfields(),
+        fields = self.datatype_class.get_field_names(
+            return_fields=self.valid_returnfields,
             include_subtypes=False)
 
-        assert fields == list(self.get_valid_returnfields())
+        assert fields == list(self.valid_returnfields)
 
     def test_get_field_names_returnfields_order(self):
         """Test the get_field_names method when specifying return
@@ -765,12 +692,12 @@ class AbstractTestTypes(object):
         parameter.
 
         """
-        rf = list(self.get_valid_returnfields())
+        rf = list(self.valid_returnfields)
 
-        while rf == list(self.get_valid_returnfields()):
+        while rf == list(self.valid_returnfields):
             random.shuffle(rf)
 
-        fields = self.get_type().get_field_names(
+        fields = self.datatype_class.get_field_names(
             return_fields=rf,
             include_subtypes=False)
 
@@ -783,11 +710,11 @@ class AbstractTestTypes(object):
         Test whether an InvalidFieldError is raised.
 
         """
-        return_fields = list(self.get_valid_returnfields())
-        return_fields.append(self.get_inexistent_field())
+        return_fields = list(self.valid_returnfields)
+        return_fields.append(self.inexistent_field)
 
         with pytest.raises(InvalidFieldError):
-            self.get_type().get_field_names(
+            self.datatype_class.get_field_names(
                 return_fields=return_fields,
                 include_subtypes=False)
 
@@ -799,8 +726,8 @@ class AbstractTestTypes(object):
 
         """
         with pytest.raises(AttributeError):
-            self.get_type().get_field_names(
-                return_fields=self.get_valid_returnfields()[0],
+            self.datatype_class.get_field_names(
+                return_fields=self.valid_returnfields[0],
                 include_subtypes=False)
 
     def test_get_field_names_wrongreturnfields_nosubtypes(self):
@@ -811,8 +738,8 @@ class AbstractTestTypes(object):
 
         """
         with pytest.raises(InvalidFieldError):
-            self.get_type().get_field_names(
-                return_fields=self.get_valid_returnfields_subtype(),
+            self.datatype_class.get_field_names(
+                return_fields=self.valid_returnfields_subtype,
                 include_subtypes=False)
 
     def test_get_fields(self):
@@ -822,7 +749,7 @@ class AbstractTestTypes(object):
         requirements and the format listed in the docs.
 
         """
-        fields = self.get_type().get_fields()
+        fields = self.datatype_class.get_fields()
 
         assert isinstance(fields, OrderedDict)
 
@@ -878,9 +805,9 @@ class AbstractTestTypes(object):
         Test whether fields provides by subtypes are not listed in the output.
 
         """
-        fields = self.get_type().get_fields(include_subtypes=False)
+        fields = self.datatype_class.get_fields(include_subtypes=False)
         for field in fields:
-            assert field not in self.get_field_names_subtypes()
+            assert field not in self.field_names_subtypes
 
     def test_from_wfs_element(self, wfs_feature):
         """Test the from_wfs_element method.
@@ -894,12 +821,12 @@ class AbstractTestTypes(object):
             the WFS layer.
 
         """
-        feature = self.get_type().from_wfs_element(
-            wfs_feature, self.get_namespace())
+        feature = self.datatype_class.from_wfs_element(
+            wfs_feature, self.namespace)
 
-        assert type(feature) is self.get_type()
+        assert type(feature) is self.datatype_class
 
-        assert feature.pkey.startswith(self.get_pkey_base())
+        assert feature.pkey.startswith(self.pkey_base)
 
         assert feature.pkey.startswith(
             build_dov_url('data/{}/'.format(feature.typename)))
@@ -921,10 +848,10 @@ class AbstractTestTypes(object):
             Monkeypatch the call to get the remote XML data.
 
         """
-        feature = self.get_type().from_wfs_element(
-            wfs_feature, self.get_namespace())
+        feature = self.datatype_class.from_wfs_element(
+            wfs_feature, self.namespace)
 
-        fields = [f for f in self.get_type().get_fields(
+        fields = [f for f in self.datatype_class.get_fields(
             source=('wfs', 'xml', 'custom')).values() if not
             f.get('wfs_injected', False)]
 
@@ -963,11 +890,11 @@ class AbstractTestTypes(object):
             the WFS layer.
 
         """
-        feature = self.get_type().from_wfs_element(
-            wfs_feature, self.get_namespace())
+        feature = self.datatype_class.from_wfs_element(
+            wfs_feature, self.namespace)
 
         with pytest.raises(InvalidFieldError):
-            feature.get_df_array(return_fields=(self.get_inexistent_field(),))
+            feature.get_df_array(return_fields=(self.inexistent_field,))
 
     def test_from_wfs_str(self, wfs_getfeature):
         """Test the from_wfs method to construct objects from a WFS response,
@@ -979,11 +906,11 @@ class AbstractTestTypes(object):
             Fixture providing a WFS GetFeature response.
 
         """
-        features = self.get_type().from_wfs(wfs_getfeature,
-                                            self.get_namespace())
+        features = self.datatype_class.from_wfs(wfs_getfeature,
+                                            self.namespace)
 
         for feature in features:
-            assert type(feature) is self.get_type()
+            assert type(feature) is self.datatype_class
 
     def test_from_wfs_bytes(self, wfs_getfeature):
         """Test the from_wfs method to construct objects from a WFS response,
@@ -995,11 +922,11 @@ class AbstractTestTypes(object):
             Fixture providing a WFS GetFeature response.
 
         """
-        features = self.get_type().from_wfs(wfs_getfeature.encode('utf-8'),
-                                            self.get_namespace())
+        features = self.datatype_class.from_wfs(wfs_getfeature.encode('utf-8'),
+                                            self.namespace)
 
         for feature in features:
-            assert type(feature) is self.get_type()
+            assert type(feature) is self.datatype_class
 
     def test_from_wfs_tree(self, wfs_getfeature):
         """Test the from_wfs method to construct objects from a WFS response,
@@ -1012,10 +939,10 @@ class AbstractTestTypes(object):
 
         """
         tree = etree.fromstring(wfs_getfeature.encode('utf8'))
-        features = self.get_type().from_wfs(tree, self.get_namespace())
+        features = self.datatype_class.from_wfs(tree, self.namespace)
 
         for feature in features:
-            assert type(feature) is self.get_type()
+            assert type(feature) is self.datatype_class
 
     def test_from_wfs_list(self, wfs_getfeature):
         """Test the from_wfs method to construct objects from a WFS response,
@@ -1034,10 +961,10 @@ class AbstractTestTypes(object):
         if feature_members is not None:
             fts = [ft for ft in feature_members]
 
-            features = self.get_type().from_wfs(fts, self.get_namespace())
+            features = self.datatype_class.from_wfs(fts, self.namespace)
 
             for feature in features:
-                assert type(feature) is self.get_type()
+                assert type(feature) is self.datatype_class
 
     def test_missing_pkey(self):
         """Test initialising an object type with a pkey of 'None'.
@@ -1046,4 +973,4 @@ class AbstractTestTypes(object):
 
         """
         with pytest.raises(ValueError):
-            self.get_type()(None)
+            self.datatype_class(None)

--- a/tests/abstract.py
+++ b/tests/abstract.py
@@ -2,36 +2,24 @@ import datetime
 import random
 import re
 import sys
-
-import numpy as np
 from collections import OrderedDict
 
+import numpy as np
 import pandas as pd
 import pytest
 import requests
+from owslib.etree import etree
+from owslib.fes import PropertyIsEqualTo, SortBy, SortProperty
 from pandas import DataFrame
-from pandas.api.types import (
-    is_int64_dtype, is_object_dtype,
-    is_bool_dtype, is_float_dtype)
+from pandas.api.types import (is_bool_dtype, is_float_dtype, is_int64_dtype,
+                              is_object_dtype)
 
 import pydov
-from owslib.fes import (
-    PropertyIsEqualTo,
-    SortBy,
-    SortProperty,
-)
-from owslib.etree import etree
 from pydov.types.abstract import AbstractField
 from pydov.util.dovutil import build_dov_url
 from pydov.util.errors import InvalidFieldError
-from pydov.util.location import (
-    Within,
-    Box,
-)
-from pydov.util.query import (
-    PropertyInList,
-    Join,
-)
+from pydov.util.location import Box, Within
+from pydov.util.query import Join, PropertyInList
 
 
 def service_ok(timeout=5):
@@ -107,7 +95,7 @@ class AbstractTestSearch(object):
             Instance of subclass of this type used for searching.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_type(self):
         """Get the class reference for this datatype.
@@ -118,7 +106,7 @@ class AbstractTestSearch(object):
             Class reference for the corresponding datatype.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_valid_query_single(self):
         """Get a valid query returning a single feature.
@@ -129,7 +117,7 @@ class AbstractTestSearch(object):
             OGC expression of the query.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_inexistent_field(self):
         """Get the name of a field that doesn't exist.
@@ -140,7 +128,7 @@ class AbstractTestSearch(object):
             The name of an inexistent field.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_wfs_field(self):
         """Get the name of a WFS field.
@@ -151,7 +139,7 @@ class AbstractTestSearch(object):
             The name of the WFS field.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_xml_field(self):
         """Get the name of a field defined in XML only.
@@ -162,7 +150,7 @@ class AbstractTestSearch(object):
             The name of the XML field.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_valid_returnfields(self):
         """Get a list of valid return fields from the main type.
@@ -173,7 +161,7 @@ class AbstractTestSearch(object):
             A tuple containing only valid return fields.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_valid_returnfields_subtype(self):
         """Get a list of valid return fields, including fields from a subtype.
@@ -185,7 +173,7 @@ class AbstractTestSearch(object):
             subtype.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_valid_returnfields_extra(self):
         """Get a list of valid return fields, including extra WFS only
@@ -198,7 +186,7 @@ class AbstractTestSearch(object):
             from WFS, not present in the default dataframe.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_df_default_columns(self):
         """Get a list of the column names (and order) from the default
@@ -210,7 +198,7 @@ class AbstractTestSearch(object):
             A list of the column names of the default dataframe.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def test_pluggable_type(self):
         """Test whether the search object can be initialised by explicitly
@@ -588,7 +576,7 @@ class AbstractTestSearch(object):
 
         """
         with pytest.raises(InvalidFieldError):
-            df = self.get_search_object().search(
+            self.get_search_object().search(
                 query=self.get_valid_query_single(),
                 sort_by=SortBy([SortProperty(
                     self.get_xml_field())]))
@@ -612,7 +600,7 @@ class AbstractTestSearch(object):
             Monkeypatch the call to break fetching of remote XML data.
 
         """
-        df = self.get_search_object().search(
+        self.get_search_object().search(
             query=self.get_valid_query_single(),
             return_fields=self.get_valid_returnfields_extra())
 
@@ -655,7 +643,7 @@ class AbstractTestSearch(object):
         df1 = self.get_search_object().search(
             query=self.get_valid_query_single())
 
-        df2 = self.get_search_object().search(
+        self.get_search_object().search(
             query=Join(df1, self.get_df_default_columns()[0]))
 
     def test_get_fields_xsd_values(self, mp_remote_xsd):
@@ -1141,4 +1129,4 @@ class AbstractTestTypes(object):
 
         """
         with pytest.raises(ValueError):
-            instance = self.get_type()(None)
+            self.get_type()(None)

--- a/tests/abstract.py
+++ b/tests/abstract.py
@@ -709,7 +709,7 @@ class AbstractTestTypes(object):
             Class reference for the corresponding datatype.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_namespace(self):
         """Get the WFS namespace associated with this datatype.
@@ -720,7 +720,7 @@ class AbstractTestTypes(object):
             WFS namespace for this type.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_pkey_base(self):
         """Get the base URL for the permanent keys of this datatype.
@@ -732,7 +732,7 @@ class AbstractTestTypes(object):
             "https://www.dov.vlaanderen.be/data/boring/"
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_field_names(self):
         """Get the field names for this type as listed in the documentation in
@@ -744,7 +744,7 @@ class AbstractTestTypes(object):
             List of field names.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_field_names_subtypes(self):
         """Get the field names of this type that originate from subtypes only.
@@ -755,7 +755,7 @@ class AbstractTestTypes(object):
             List of field names from subtypes.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_field_names_nosubtypes(self):
         """Get the field names for this type, without including fields from
@@ -767,7 +767,7 @@ class AbstractTestTypes(object):
             List of field names.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_valid_returnfields(self):
         """Get a list of valid return fields from the main type.
@@ -778,7 +778,7 @@ class AbstractTestTypes(object):
             A tuple containing only valid return fields.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_valid_returnfields_subtype(self):
         """Get a list of valid return fields, including fields from a subtype.
@@ -790,7 +790,7 @@ class AbstractTestTypes(object):
             subtype.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def get_inexistent_field(self):
         """Get the name of a field that doesn't exist.
@@ -801,7 +801,7 @@ class AbstractTestTypes(object):
             The name of an inexistent field.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError('This should be implemented in a subclass.')
 
     def test_get_field_names(self):
         """Test the get_field_names method.

--- a/tests/test_search_boring.py
+++ b/tests/test_search_boring.py
@@ -50,43 +50,29 @@ def md_metadata(wfs, mp_remote_md):
 
 
 class TestBoringSearch(AbstractTestSearch):
-    def get_search_object(self):
-        return BoringSearch()
 
-    def get_type(self):
-        return Boring
+    search_instance = BoringSearch()
+    datatype_class = Boring
 
-    def get_valid_query_single(self):
-        return PropertyIsEqualTo(propertyname='boornummer',
-                                 literal='GEO-04/169-BNo-B1')
+    valid_query_single = PropertyIsEqualTo(propertyname='boornummer',
+                                           literal='GEO-04/169-BNo-B1')
 
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'
+    wfs_field = 'boornummer'
+    xml_field = 'boormethode'
 
-    def get_wfs_field(self):
-        return 'boornummer'
+    valid_returnfields = ('pkey_boring', 'boornummer', 'diepte_boring_tot',
+                          'datum_aanvang')
+    valid_returnfields_subtype = ('pkey_boring', 'boornummer',
+                                  'diepte_methode_van', 'diepte_methode_tot')
+    valid_returnfields_extra = ('pkey_boring', 'doel')
 
-    def get_xml_field(self):
-        return 'boormethode'
-
-    def get_valid_returnfields(self):
-        return ('pkey_boring', 'boornummer', 'diepte_boring_tot',
-                'datum_aanvang')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_boring', 'boornummer', 'diepte_methode_van',
-                'diepte_methode_tot')
-
-    def get_valid_returnfields_extra(self):
-        return ('pkey_boring', 'doel')
-
-    def get_df_default_columns(self):
-        return ['pkey_boring', 'boornummer', 'x', 'y', 'mv_mtaw',
-                'start_boring_mtaw', 'gemeente',
-                'diepte_boring_van', 'diepte_boring_tot',
-                'datum_aanvang', 'uitvoerder', 'boorgatmeting',
-                'diepte_methode_van', 'diepte_methode_tot',
-                'boormethode']
+    df_default_columns = ['pkey_boring', 'boornummer', 'x', 'y', 'mv_mtaw',
+                          'start_boring_mtaw', 'gemeente',
+                          'diepte_boring_van', 'diepte_boring_tot',
+                          'datum_aanvang', 'uitvoerder', 'boorgatmeting',
+                          'diepte_methode_van', 'diepte_methode_tot',
+                          'boormethode']
 
     def test_search_date(self, mp_wfs, mp_get_schema,
                          mp_remote_describefeaturetype, mp_remote_md,
@@ -113,8 +99,8 @@ class TestBoringSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single())
+        df = self.search_instance.search(
+            query=self.valid_query_single)
 
         # specific test for the Zulu time wfs 1.1.0 issue
         assert df.datum_aanvang.unique()[0] == datetime.date(2004, 12, 20)
@@ -144,8 +130,8 @@ class TestBoringSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single())
+        df = self.search_instance.search(
+            query=self.valid_query_single)
 
         assert df.mv_mtaw.hasnans
 
@@ -169,8 +155,8 @@ class TestBoringSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_boring', 'boornummer', 'boorgatmeting'))
 
         assert not df.boorgatmeting[0]

--- a/tests/test_search_boring.py
+++ b/tests/test_search_boring.py
@@ -50,13 +50,10 @@ def md_metadata(wfs, mp_remote_md):
 
 
 class TestBoringSearch(AbstractTestSearch):
-    search_object = BoringSearch()
-
     def get_search_object(self):
         return BoringSearch()
 
     def get_type(self):
-
         return Boring
 
     def get_valid_query_single(self):

--- a/tests/test_search_boring.py
+++ b/tests/test_search_boring.py
@@ -2,29 +2,17 @@
 import datetime
 
 import pytest
-
 from owslib.fes import PropertyIsEqualTo
+
 from pydov.search.boring import BoringSearch
 from pydov.types.boring import Boring
 from pydov.util import owsutil
-from tests.abstract import (
-    AbstractTestSearch,
-)
-
-from tests.test_search import (
-    mp_wfs,
-    wfs,
-    mp_get_schema,
-    mp_remote_md,
-    mp_remote_fc,
-    mp_remote_describefeaturetype,
-    mp_remote_wfs_feature,
-    mp_remote_xsd,
-    mp_dov_xml,
-    mp_dov_xml_broken,
-    wfs_getfeature,
-    wfs_feature,
-)
+from tests.abstract import AbstractTestSearch
+from tests.test_search import (mp_dov_xml, mp_dov_xml_broken, mp_get_schema,
+                               mp_remote_describefeaturetype, mp_remote_fc,
+                               mp_remote_md, mp_remote_wfs_feature,
+                               mp_remote_xsd, mp_wfs, wfs, wfs_feature,
+                               wfs_getfeature)
 
 location_md_metadata = 'tests/data/types/boring/md_metadata.xml'
 location_fc_featurecatalogue = \
@@ -62,121 +50,40 @@ def md_metadata(wfs, mp_remote_md):
 
 
 class TestBoringSearch(AbstractTestSearch):
+    search_object = BoringSearch()
+
     def get_search_object(self):
-        """Get an instance of the search object for this type.
-
-        Returns
-        -------
-        pydov.search.boring.BoringSearch
-            Instance of BoringSearch used for searching.
-
-        """
         return BoringSearch()
 
     def get_type(self):
-        """Get the class reference for this datatype.
 
-        Returns
-        -------
-        pydov.types.boring.Boring
-            Class reference for the Boring class.
-
-        """
         return Boring
 
     def get_valid_query_single(self):
-        """Get a valid query returning a single feature.
-
-        Returns
-        -------
-        owslib.fes.OgcExpression
-            OGC expression of the query.
-
-        """
         return PropertyIsEqualTo(propertyname='boornummer',
                                  literal='GEO-04/169-BNo-B1')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
 
     def get_wfs_field(self):
-        """Get the name of a WFS field.
-
-        Returns
-        -------
-        str
-            The name of the WFS field.
-
-        """
         return 'boornummer'
 
     def get_xml_field(self):
-        """Get the name of a field defined in XML only.
-
-        Returns
-        -------
-        str
-            The name of the XML field.
-
-        """
         return 'boormethode'
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_boring', 'boornummer', 'diepte_boring_tot',
                 'datum_aanvang')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_boring', 'boornummer', 'diepte_methode_van',
                 'diepte_methode_tot')
 
     def get_valid_returnfields_extra(self):
-        """Get a list of valid return fields, including extra WFS only
-        fields not present in the default dataframe.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including extra fields
-            from WFS, not present in the default dataframe.
-
-        """
         return ('pkey_boring', 'doel')
 
     def get_df_default_columns(self):
-        """Get a list of the column names (and order) from the default
-        dataframe.
-
-        Returns
-        -------
-        list
-            A list of the column names of the default dataframe.
-
-        """
         return ['pkey_boring', 'boornummer', 'x', 'y', 'mv_mtaw',
                 'start_boring_mtaw', 'gemeente',
                 'diepte_boring_van', 'diepte_boring_tot',

--- a/tests/test_search_grondmonster.py
+++ b/tests/test_search_grondmonster.py
@@ -2,26 +2,15 @@
 import datetime
 
 from owslib.fes import PropertyIsEqualTo
+
 from pydov.search.grondmonster import GrondmonsterSearch
 from pydov.types.grondmonster import Grondmonster
-from tests.abstract import (
-    AbstractTestSearch,
-)
-
-from tests.test_search import (
-    mp_wfs,
-    wfs,
-    mp_get_schema,
-    mp_remote_md,
-    mp_remote_fc,
-    mp_remote_describefeaturetype,
-    mp_remote_wfs_feature,
-    mp_remote_xsd,
-    mp_dov_xml,
-    mp_dov_xml_broken,
-    wfs_getfeature,
-    wfs_feature,
-)
+from tests.abstract import AbstractTestSearch
+from tests.test_search import (mp_dov_xml, mp_dov_xml_broken, mp_get_schema,
+                               mp_remote_describefeaturetype, mp_remote_fc,
+                               mp_remote_md, mp_remote_wfs_feature,
+                               mp_remote_xsd, mp_wfs, wfs, wfs_feature,
+                               wfs_getfeature)
 
 location_md_metadata = 'tests/data/types/grondmonster/md_metadata.xml'
 location_fc_featurecatalogue = \
@@ -36,118 +25,34 @@ location_xsd_base = 'tests/data/types/grondmonster/xsd_*.xml'
 
 class TestGrondmonsterSearch(AbstractTestSearch):
     def get_search_object(self):
-        """Get an instance of the search object for this type.
-
-        Returns
-        -------
-        pydov.search.grondmonster.GrondmonsterSearch
-            Instance of GrondmonsterSearch used for searching.
-
-        """
         return GrondmonsterSearch()
 
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.grondmonster.Grondmonster
-            Class reference for the Grondmonster class.
-
-        """
         return Grondmonster
 
     def get_valid_query_single(self):
-        """Get a valid query returning a single feature.
-
-        Returns
-        -------
-        owslib.fes.OgcExpression
-            OGC expression of the query.
-
-        """
         return PropertyIsEqualTo(propertyname='boornummer',
                                  literal='GEO-04/024-B6')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
 
     def get_wfs_field(self):
-        """Get the name of a WFS field.
-
-        Returns
-        -------
-        str
-            The name of the WFS field.
-
-        """
         return 'boornummer'
 
     def get_xml_field(self):
-        """Get the name of a field defined in XML only.
-
-        Returns
-        -------
-        str
-            The name of the XML field.
-
-        """
         return 'astm_naam'
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_grondmonster', 'boornummer')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_grondmonster', 'boornummer', 'diameter')
 
     def get_valid_returnfields_extra(self):
-        """Get a list of valid return fields, including extra WFS only
-        fields not present in the default dataframe.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including extra fields
-            from WFS, not present in the default dataframe.
-
-        """
         return ('pkey_grondmonster', 'korrelverdeling')
 
     def get_df_default_columns(self):
-        """Get a list of the column names (and order) from the default
-        dataframe.
-
-        Returns
-        -------
-        list
-            A list of the column names of the default dataframe.
-
-        """
         return ['pkey_grondmonster', 'naam', 'pkey_boring', 'boornummer',
                 'datum', 'x', 'y', 'gemeente', 'diepte_van_m', 'diepte_tot_m',
                 'peil_van_mtaw', 'peil_tot_mtaw', 'monstertype', 'astm_naam',

--- a/tests/test_search_grondmonster.py
+++ b/tests/test_search_grondmonster.py
@@ -24,42 +24,29 @@ location_xsd_base = 'tests/data/types/grondmonster/xsd_*.xml'
 
 
 class TestGrondmonsterSearch(AbstractTestSearch):
-    def get_search_object(self):
-        return GrondmonsterSearch()
 
-    def get_type(self):
-        return Grondmonster
+    search_instance = GrondmonsterSearch()
+    datatype_class = Grondmonster
 
-    def get_valid_query_single(self):
-        return PropertyIsEqualTo(propertyname='boornummer',
-                                 literal='GEO-04/024-B6')
+    valid_query_single = PropertyIsEqualTo(propertyname='boornummer',
+                                           literal='GEO-04/024-B6')
 
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'
+    wfs_field = 'boornummer'
+    xml_field = 'astm_naam'
 
-    def get_wfs_field(self):
-        return 'boornummer'
+    valid_returnfields = ('pkey_grondmonster', 'boornummer')
+    valid_returnfields_subtype = (
+        'pkey_grondmonster', 'boornummer', 'diameter')
+    valid_returnfields_extra = ('pkey_grondmonster', 'korrelverdeling')
 
-    def get_xml_field(self):
-        return 'astm_naam'
-
-    def get_valid_returnfields(self):
-        return ('pkey_grondmonster', 'boornummer')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_grondmonster', 'boornummer', 'diameter')
-
-    def get_valid_returnfields_extra(self):
-        return ('pkey_grondmonster', 'korrelverdeling')
-
-    def get_df_default_columns(self):
-        return ['pkey_grondmonster', 'naam', 'pkey_boring', 'boornummer',
-                'datum', 'x', 'y', 'gemeente', 'diepte_van_m', 'diepte_tot_m',
-                'peil_van_mtaw', 'peil_tot_mtaw', 'monstertype', 'astm_naam',
-                'grondsoort_bggg', 'humusgehalte', 'kalkgehalte',
-                'uitrolgrens', 'vloeigrens', 'glauconiet',
-                'korrelvolumemassa', 'volumemassa', 'watergehalte',
-                'diameter', 'fractie', 'methode']
+    df_default_columns = ['pkey_grondmonster', 'naam', 'pkey_boring', 'boornummer',
+                          'datum', 'x', 'y', 'gemeente', 'diepte_van_m', 'diepte_tot_m',
+                          'peil_van_mtaw', 'peil_tot_mtaw', 'monstertype', 'astm_naam',
+                          'grondsoort_bggg', 'humusgehalte', 'kalkgehalte',
+                          'uitrolgrens', 'vloeigrens', 'glauconiet',
+                          'korrelvolumemassa', 'volumemassa', 'watergehalte',
+                          'diameter', 'fractie', 'methode']
 
     def test_search_xmlresolving(self, mp_get_schema,
                                  mp_remote_describefeaturetype,
@@ -81,8 +68,8 @@ class TestGrondmonsterSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_grondmonster', 'boornummer', 'humusgehalte',
                            'methode'))
 

--- a/tests/test_search_grondwaterfilter.py
+++ b/tests/test_search_grondwaterfilter.py
@@ -25,44 +25,31 @@ location_xsd_base = 'tests/data/types/grondwaterfilter/xsd_*.xml'
 
 
 class TestGrondwaterfilterSearch(AbstractTestSearch):
-    def get_search_object(self):
-        return GrondwaterFilterSearch()
 
-    def get_type(self):
-        return GrondwaterFilter
+    search_instance = GrondwaterFilterSearch()
+    datatype_class = GrondwaterFilter
 
-    def get_valid_query_single(self):
-        return PropertyIsEqualTo(propertyname='filterfiche',
-                                 literal=build_dov_url(
-                                     'data/filter/2003-004471'))
+    valid_query_single = PropertyIsEqualTo(propertyname='filterfiche',
+                                           literal=build_dov_url(
+                                               'data/filter/2003-004471'))
 
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'
+    wfs_field = 'filternummer'
+    xml_field = 'peil_mtaw'
 
-    def get_wfs_field(self):
-        return 'filternummer'
+    valid_returnfields = ('pkey_filter', 'filternummer')
+    valid_returnfields_subtype = ('pkey_filter', 'filternummer', 'peil_mtaw')
+    valid_returnfields_extra = ('pkey_filter', 'beheerder')
 
-    def get_xml_field(self):
-        return 'peil_mtaw'
-
-    def get_valid_returnfields(self):
-        return ('pkey_filter', 'filternummer')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_filter', 'filternummer', 'peil_mtaw')
-
-    def get_valid_returnfields_extra(self):
-        return ('pkey_filter', 'beheerder')
-
-    def get_df_default_columns(self):
-        return ['pkey_filter', 'pkey_grondwaterlocatie', 'gw_id',
-                'filternummer', 'filtertype', 'x', 'y',
-                'start_grondwaterlocatie_mtaw', 'mv_mtaw',
-                'gemeente', 'meetnet_code', 'aquifer_code',
-                'grondwaterlichaam_code', 'regime',
-                'diepte_onderkant_filter', 'lengte_filter',
-                'datum', 'tijdstip', 'peil_mtaw',
-                'betrouwbaarheid', 'methode', 'filterstatus', 'filtertoestand']
+    df_default_columns = ['pkey_filter', 'pkey_grondwaterlocatie', 'gw_id',
+                          'filternummer', 'filtertype', 'x', 'y',
+                          'start_grondwaterlocatie_mtaw', 'mv_mtaw',
+                          'gemeente', 'meetnet_code', 'aquifer_code',
+                          'grondwaterlichaam_code', 'regime',
+                          'diepte_onderkant_filter', 'lengte_filter',
+                          'datum', 'tijdstip', 'peil_mtaw',
+                          'betrouwbaarheid', 'methode', 'filterstatus',
+                          'filtertoestand']
 
     def test_search_date(self, mp_wfs, mp_get_schema,
                          mp_remote_describefeaturetype, mp_remote_md,
@@ -89,8 +76,8 @@ class TestGrondwaterfilterSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single())
+        df = self.search_instance.search(
+            query=self.valid_query_single)
 
         # specific test for the Zulu time wfs 1.1.0 issue
         assert df.datum.sort_values()[0] == datetime.date(2004, 4, 7)
@@ -115,8 +102,8 @@ class TestGrondwaterfilterSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_filter', 'gw_id', 'filternummer',
                            'meetnet_code'))
 

--- a/tests/test_search_grondwaterfilter.py
+++ b/tests/test_search_grondwaterfilter.py
@@ -2,27 +2,16 @@
 import datetime
 
 from owslib.fes import PropertyIsEqualTo
+
 from pydov.search.grondwaterfilter import GrondwaterFilterSearch
 from pydov.types.grondwaterfilter import GrondwaterFilter
 from pydov.util.dovutil import build_dov_url
-from tests.abstract import (
-    AbstractTestSearch,
-)
-
-from tests.test_search import (
-    mp_wfs,
-    wfs,
-    mp_get_schema,
-    mp_remote_md,
-    mp_remote_fc,
-    mp_remote_describefeaturetype,
-    mp_remote_wfs_feature,
-    mp_remote_xsd,
-    mp_dov_xml,
-    mp_dov_xml_broken,
-    wfs_getfeature,
-    wfs_feature,
-)
+from tests.abstract import AbstractTestSearch
+from tests.test_search import (mp_dov_xml, mp_dov_xml_broken, mp_get_schema,
+                               mp_remote_describefeaturetype, mp_remote_fc,
+                               mp_remote_md, mp_remote_wfs_feature,
+                               mp_remote_xsd, mp_wfs, wfs, wfs_feature,
+                               wfs_getfeature)
 
 location_md_metadata = 'tests/data/types/grondwaterfilter/md_metadata.xml'
 location_fc_featurecatalogue = \
@@ -37,119 +26,35 @@ location_xsd_base = 'tests/data/types/grondwaterfilter/xsd_*.xml'
 
 class TestGrondwaterfilterSearch(AbstractTestSearch):
     def get_search_object(self):
-        """Get an instance of the search object for this type.
-
-        Returns
-        -------
-        pydov.search.grondwaterfilter.GrondwaterFilterSearch
-            Instance of GrondwaterFilterSearch used for searching.
-
-        """
         return GrondwaterFilterSearch()
 
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.grondwaterfilter.GrondwaterFilter
-            Class reference for the GrondwaterFilter class.
-
-        """
         return GrondwaterFilter
 
     def get_valid_query_single(self):
-        """Get a valid query returning a single feature.
-
-        Returns
-        -------
-        owslib.fes.OgcExpression
-            OGC expression of the query.
-
-        """
         return PropertyIsEqualTo(propertyname='filterfiche',
                                  literal=build_dov_url(
                                      'data/filter/2003-004471'))
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
 
     def get_wfs_field(self):
-        """Get the name of a WFS field.
-
-        Returns
-        -------
-        str
-            The name of the WFS field.
-
-        """
         return 'filternummer'
 
     def get_xml_field(self):
-        """Get the name of a field defined in XML only.
-
-        Returns
-        -------
-        str
-            The name of the XML field.
-
-        """
         return 'peil_mtaw'
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_filter', 'filternummer')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_filter', 'filternummer', 'peil_mtaw')
 
     def get_valid_returnfields_extra(self):
-        """Get a list of valid return fields, including extra WFS only
-        fields not present in the default dataframe.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including extra fields
-            from WFS, not present in the default dataframe.
-
-        """
         return ('pkey_filter', 'beheerder')
 
     def get_df_default_columns(self):
-        """Get a list of the column names (and order) from the default
-        dataframe.
-
-        Returns
-        -------
-        list
-            A list of the column names of the default dataframe.
-
-        """
         return ['pkey_filter', 'pkey_grondwaterlocatie', 'gw_id',
                 'filternummer', 'filtertype', 'x', 'y',
                 'start_grondwaterlocatie_mtaw', 'mv_mtaw',

--- a/tests/test_search_grondwatermonster.py
+++ b/tests/test_search_grondwatermonster.py
@@ -24,41 +24,30 @@ location_xsd_base = 'tests/data/types/grondwatermonster/xsd_*.xml'
 
 
 class TestGrondwaterMonsterSearch(AbstractTestSearch):
-    def get_search_object(self):
-        return GrondwaterMonsterSearch()
 
-    def get_type(self):
-        return GrondwaterMonster
+    search_instance = GrondwaterMonsterSearch()
+    datatype_class = GrondwaterMonster
 
-    def get_valid_query_single(self):
-        return PropertyIsEqualTo(propertyname='grondwatermonsterfiche',
-                                 literal='https://www.dov.vlaanderen.be/data/'
-                                         'watermonster/2006-115684')
+    valid_query_single = PropertyIsEqualTo(
+        propertyname='grondwatermonsterfiche',
+        literal='https://www.dov.vlaanderen.be/data/'
+        'watermonster/2006-115684')
 
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'
+    wfs_field = 'kationen'
+    xml_field = 'eenheid'
 
-    def get_wfs_field(self):
-        return 'kationen'
+    valid_returnfields = ('pkey_grondwatermonster', 'datum_monstername')
+    valid_returnfields_subtype = (
+        'pkey_grondwatermonster', 'datum_monstername', 'eenheid')
+    valid_returnfields_extra = ('pkey_grondwatermonster', 'kationen')
 
-    def get_xml_field(self):
-        return 'eenheid'
-
-    def get_valid_returnfields(self):
-        return ('pkey_grondwatermonster', 'datum_monstername')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_grondwatermonster', 'datum_monstername', 'eenheid')
-
-    def get_valid_returnfields_extra(self):
-        return ('pkey_grondwatermonster', 'kationen')
-
-    def get_df_default_columns(self):
-        return ['pkey_grondwatermonster', 'grondwatermonsternummer',
-                'pkey_grondwaterlocatie', 'gw_id', 'pkey_filter',
-                'filternummer', 'x', 'y', 'start_grondwaterlocatie_mtaw',
-                'gemeente', 'datum_monstername', 'parametergroep',
-                'parameter', 'detectie', 'waarde', 'eenheid', 'veld_labo']
+    df_default_columns = [
+        'pkey_grondwatermonster', 'grondwatermonsternummer',
+        'pkey_grondwaterlocatie', 'gw_id', 'pkey_filter',
+        'filternummer', 'x', 'y', 'start_grondwaterlocatie_mtaw',
+        'gemeente', 'datum_monstername', 'parametergroep',
+        'parameter', 'detectie', 'waarde', 'eenheid', 'veld_labo']
 
     def test_search_date(self, mp_wfs, mp_get_schema,
                          mp_remote_describefeaturetype, mp_remote_md,
@@ -85,8 +74,8 @@ class TestGrondwaterMonsterSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single())
+        df = self.search_instance.search(
+            query=self.valid_query_single)
 
         # specific test for the Zulu time wfs 1.1.0 issue
         assert df.datum_monstername.sort_values()[0] == datetime.date(

--- a/tests/test_search_grondwatermonster.py
+++ b/tests/test_search_grondwatermonster.py
@@ -2,26 +2,15 @@
 import datetime
 
 from owslib.fes import PropertyIsEqualTo
+
 from pydov.search.grondwatermonster import GrondwaterMonsterSearch
 from pydov.types.grondwatermonster import GrondwaterMonster
-from tests.abstract import (
-    AbstractTestSearch,
-)
-
-from tests.test_search import (
-    mp_wfs,
-    wfs,
-    mp_get_schema,
-    mp_remote_md,
-    mp_remote_fc,
-    mp_remote_describefeaturetype,
-    mp_remote_wfs_feature,
-    mp_remote_xsd,
-    mp_dov_xml,
-    mp_dov_xml_broken,
-    wfs_getfeature,
-    wfs_feature,
-)
+from tests.abstract import AbstractTestSearch
+from tests.test_search import (mp_dov_xml, mp_dov_xml_broken, mp_get_schema,
+                               mp_remote_describefeaturetype, mp_remote_fc,
+                               mp_remote_md, mp_remote_wfs_feature,
+                               mp_remote_xsd, mp_wfs, wfs, wfs_feature,
+                               wfs_getfeature)
 
 location_md_metadata = 'tests/data/types/grondwatermonster/md_metadata.xml'
 location_fc_featurecatalogue = \
@@ -36,119 +25,35 @@ location_xsd_base = 'tests/data/types/grondwatermonster/xsd_*.xml'
 
 class TestGrondwaterMonsterSearch(AbstractTestSearch):
     def get_search_object(self):
-        """Get an instance of the search object for this type.
-
-        Returns
-        -------
-        pydov.search.grondwatermonster.GrondwaterMonsterSearch
-            Instance of GrondwaterMonsterSearch used for searching.
-
-        """
         return GrondwaterMonsterSearch()
 
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.grondwatermonster.GrondwaterMonster
-            Class reference for the GrondwaterMonster class.
-
-        """
         return GrondwaterMonster
 
     def get_valid_query_single(self):
-        """Get a valid query returning a single feature.
-
-        Returns
-        -------
-        owslib.fes.OgcExpression
-            OGC expression of the query.
-
-        """
         return PropertyIsEqualTo(propertyname='grondwatermonsterfiche',
                                  literal='https://www.dov.vlaanderen.be/data/'
                                          'watermonster/2006-115684')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
 
     def get_wfs_field(self):
-        """Get the name of a WFS field.
-
-        Returns
-        -------
-        str
-            The name of the WFS field.
-
-        """
         return 'kationen'
 
     def get_xml_field(self):
-        """Get the name of a field defined in XML only.
-
-        Returns
-        -------
-        str
-            The name of the XML field.
-
-        """
         return 'eenheid'
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_grondwatermonster', 'datum_monstername')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_grondwatermonster', 'datum_monstername', 'eenheid')
 
     def get_valid_returnfields_extra(self):
-        """Get a list of valid return fields, including extra WFS only
-        fields not present in the default dataframe.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including extra fields
-            from WFS, not present in the default dataframe.
-
-        """
         return ('pkey_grondwatermonster', 'kationen')
 
     def get_df_default_columns(self):
-        """Get a list of the column names (and order) from the default
-        dataframe.
-
-        Returns
-        -------
-        list
-            A list of the column names of the default dataframe.
-
-        """
         return ['pkey_grondwatermonster', 'grondwatermonsternummer',
                 'pkey_grondwaterlocatie', 'gw_id', 'pkey_filter',
                 'filternummer', 'x', 'y', 'start_grondwaterlocatie_mtaw',
@@ -184,5 +89,5 @@ class TestGrondwaterMonsterSearch(AbstractTestSearch):
             query=self.get_valid_query_single())
 
         # specific test for the Zulu time wfs 1.1.0 issue
-        assert df.datum_monstername.sort_values()[0] == datetime.date(2006, 5, 19)
-
+        assert df.datum_monstername.sort_values()[0] == datetime.date(
+            2006, 5, 19)

--- a/tests/test_search_itp_formelestratigrafie.py
+++ b/tests/test_search_itp_formelestratigrafie.py
@@ -33,40 +33,28 @@ location_xsd_base = \
 
 
 class TestFormeleStratigrafieSearch(AbstractTestSearch):
-    def get_search_object(self):
-        return FormeleStratigrafieSearch()
 
-    def get_type(self):
-        return FormeleStratigrafie
+    search_instance = FormeleStratigrafieSearch()
+    datatype_class = FormeleStratigrafie
 
-    def get_valid_query_single(self):
-        return PropertyIsEqualTo(propertyname='Proefnummer',
-                                 literal='GEO-64/340-S3')
+    valid_query_single = PropertyIsEqualTo(propertyname='Proefnummer',
+                                           literal='GEO-64/340-S3')
 
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'
+    wfs_field = 'Proefnummer'
+    xml_field = 'diepte_laag_van'
 
-    def get_wfs_field(self):
-        return 'Proefnummer'
+    valid_returnfields = ('pkey_interpretatie',
+                          'betrouwbaarheid_interpretatie')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
+    valid_returnfields_extra = ('pkey_interpretatie', 'gemeente')
 
-    def get_xml_field(self):
-        return 'diepte_laag_van'
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_valid_returnfields_extra(self):
-        return ('pkey_interpretatie', 'gemeente')
-
-    def get_df_default_columns(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'pkey_sondering',
-                'betrouwbaarheid_interpretatie', 'x', 'y',
-                'diepte_laag_van', 'diepte_laag_tot',
-                'lid1', 'relatie_lid1_lid2', 'lid2']
+    df_default_columns = ['pkey_interpretatie', 'pkey_boring',
+                          'pkey_sondering',
+                          'betrouwbaarheid_interpretatie', 'x', 'y',
+                          'diepte_laag_van', 'diepte_laag_tot',
+                          'lid1', 'relatie_lid1_lid2', 'lid2']
 
     def test_search_nan(self, mp_wfs, mp_get_schema,
                         mp_remote_describefeaturetype, mp_remote_md,
@@ -93,8 +81,8 @@ class TestFormeleStratigrafieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single())
+        df = self.search_instance.search(
+            query=self.valid_query_single)
 
         assert df.pkey_boring.hasnans
 
@@ -117,8 +105,8 @@ class TestFormeleStratigrafieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'pkey_boring',
                            'pkey_sondering'))
 
@@ -150,8 +138,8 @@ class TestFormeleStratigrafieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'diepte_laag_tot'))
 
         assert df.diepte_laag_tot[0] == 8.0

--- a/tests/test_search_itp_formelestratigrafie.py
+++ b/tests/test_search_itp_formelestratigrafie.py
@@ -1,31 +1,19 @@
 """Module grouping tests for the interpretaties search module."""
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
+from owslib.fes import PropertyIsEqualTo
 from pandas import DataFrame
 
 import pydov
-from owslib.fes import PropertyIsEqualTo
 from pydov.search.interpretaties import FormeleStratigrafieSearch
 from pydov.types.interpretaties import FormeleStratigrafie
-from tests.abstract import (
-    AbstractTestSearch,
-)
-
-from tests.test_search import (
-    mp_wfs,
-    wfs,
-    mp_get_schema,
-    mp_remote_md,
-    mp_remote_fc,
-    mp_remote_describefeaturetype,
-    mp_remote_wfs_feature,
-    mp_remote_xsd,
-    mp_dov_xml,
-    mp_dov_xml_broken,
-    wfs_getfeature,
-    wfs_feature,
-)
+from tests.abstract import AbstractTestSearch
+from tests.test_search import (mp_dov_xml, mp_dov_xml_broken, mp_get_schema,
+                               mp_remote_describefeaturetype, mp_remote_fc,
+                               mp_remote_md, mp_remote_wfs_feature,
+                               mp_remote_xsd, mp_wfs, wfs, wfs_feature,
+                               wfs_getfeature)
 
 location_md_metadata = \
     'tests/data/types/interpretaties/formele_stratigrafie/md_metadata.xml'
@@ -46,118 +34,34 @@ location_xsd_base = \
 
 class TestFormeleStratigrafieSearch(AbstractTestSearch):
     def get_search_object(self):
-        """Get an instance of the search object for this type.
-
-        Returns
-        -------
-        pydov.search.interpretaties.FormeleStratigrafieSearch
-            Instance of FormeleStratigrafieSearch used for searching.
-
-        """
         return FormeleStratigrafieSearch()
 
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretaties.FormeleStratigrafie
-            Class reference for the FormeleStratigrafie class.
-
-        """
         return FormeleStratigrafie
 
     def get_valid_query_single(self):
-        """Get a valid query returning a single feature.
-
-        Returns
-        -------
-        owslib.fes.OgcExpression
-            OGC expression of the query.
-
-        """
         return PropertyIsEqualTo(propertyname='Proefnummer',
                                  literal='GEO-64/340-S3')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
 
     def get_wfs_field(self):
-        """Get the name of a WFS field.
-
-        Returns
-        -------
-        str
-            The name of the WFS field.
-
-        """
         return 'Proefnummer'
 
     def get_xml_field(self):
-        """Get the name of a field defined in XML only.
-
-        Returns
-        -------
-        str
-            The name of the XML field.
-
-        """
         return 'diepte_laag_van'
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_valid_returnfields_extra(self):
-        """Get a list of valid return fields, including extra WFS only
-        fields not present in the default dataframe.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including extra fields
-            from WFS, not present in the default dataframe.
-
-        """
         return ('pkey_interpretatie', 'gemeente')
 
     def get_df_default_columns(self):
-        """Get a list of the column names (and order) from the default
-        dataframe.
-
-        Returns
-        -------
-        list
-            A list of the column names of the default dataframe.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'pkey_sondering',
                 'betrouwbaarheid_interpretatie', 'x', 'y',

--- a/tests/test_search_itp_gecodeerdelithologie.py
+++ b/tests/test_search_itp_gecodeerdelithologie.py
@@ -1,31 +1,19 @@
 """Module grouping tests for the interpretaties search module."""
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
+from owslib.fes import PropertyIsEqualTo
 from pandas import DataFrame
 
 import pydov
-from owslib.fes import PropertyIsEqualTo
 from pydov.search.interpretaties import GecodeerdeLithologieSearch
 from pydov.types.interpretaties import GecodeerdeLithologie
-from tests.abstract import (
-    AbstractTestSearch,
-)
-
-from tests.test_search import (
-    mp_wfs,
-    wfs,
-    mp_get_schema,
-    mp_remote_md,
-    mp_remote_fc,
-    mp_remote_describefeaturetype,
-    mp_remote_wfs_feature,
-    mp_remote_xsd,
-    mp_dov_xml,
-    mp_dov_xml_broken,
-    wfs_getfeature,
-    wfs_feature,
-)
+from tests.abstract import AbstractTestSearch
+from tests.test_search import (mp_dov_xml, mp_dov_xml_broken, mp_get_schema,
+                               mp_remote_describefeaturetype, mp_remote_fc,
+                               mp_remote_md, mp_remote_wfs_feature,
+                               mp_remote_xsd, mp_wfs, wfs, wfs_feature,
+                               wfs_getfeature)
 
 location_md_metadata = \
     'tests/data/types/interpretaties/gecodeerde_lithologie/' \
@@ -50,118 +38,34 @@ location_xsd_base = \
 
 class TestGecodeerdeLithologieSearch(AbstractTestSearch):
     def get_search_object(self):
-        """Get an instance of the search object for this type.
-
-        Returns
-        -------
-        pydov.search.interpretaties.GecodeerdeLithologieSearch
-            Instance of GecodeerdeLithologieSearch used for searching.
-
-        """
         return GecodeerdeLithologieSearch()
 
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretaties.GecodeerdeLithologie
-            Class reference for the GecodeerdeLithologie class.
-
-        """
         return GecodeerdeLithologie
 
     def get_valid_query_single(self):
-        """Get a valid query returning a single feature.
-
-        Returns
-        -------
-        owslib.fes.OgcExpression
-            OGC expression of the query.
-
-        """
         return PropertyIsEqualTo(propertyname='Proefnummer',
                                  literal='kb22d56w-B165')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
 
     def get_xml_field(self):
-        """Get the name of a field defined in XML only.
-
-        Returns
-        -------
-        str
-            The name of the XML field.
-
-        """
         return 'grondsoort'
 
     def get_wfs_field(self):
-        """Get the name of a WFS field.
-
-        Returns
-        -------
-        str
-            The name of the WFS field.
-
-        """
         return 'Proefnummer'
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_valid_returnfields_extra(self):
-        """Get a list of valid return fields, including extra WFS only
-        fields not present in the default dataframe.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including extra fields
-            from WFS, not present in the default dataframe.
-
-        """
         return ('pkey_interpretatie', 'gemeente')
 
     def get_df_default_columns(self):
-        """Get a list of the column names (and order) from the default
-        dataframe.
-
-        Returns
-        -------
-        list
-            A list of the column names of the default dataframe.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y',
                 'diepte_laag_van', 'diepte_laag_tot',

--- a/tests/test_search_itp_gecodeerdelithologie.py
+++ b/tests/test_search_itp_gecodeerdelithologie.py
@@ -37,44 +37,32 @@ location_xsd_base = \
 
 
 class TestGecodeerdeLithologieSearch(AbstractTestSearch):
-    def get_search_object(self):
-        return GecodeerdeLithologieSearch()
 
-    def get_type(self):
-        return GecodeerdeLithologie
+    search_instance = GecodeerdeLithologieSearch()
+    datatype_class = GecodeerdeLithologie
 
-    def get_valid_query_single(self):
-        return PropertyIsEqualTo(propertyname='Proefnummer',
-                                 literal='kb22d56w-B165')
+    valid_query_single = PropertyIsEqualTo(propertyname='Proefnummer',
+                                           literal='kb22d56w-B165')
 
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'
+    wfs_field = 'Proefnummer'
+    xml_field = 'grondsoort'
 
-    def get_xml_field(self):
-        return 'grondsoort'
+    valid_returnfields = ('pkey_interpretatie',
+                          'betrouwbaarheid_interpretatie')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
+    valid_returnfields_extra = ('pkey_interpretatie', 'gemeente')
 
-    def get_wfs_field(self):
-        return 'Proefnummer'
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_valid_returnfields_extra(self):
-        return ('pkey_interpretatie', 'gemeente')
-
-    def get_df_default_columns(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y',
-                'diepte_laag_van', 'diepte_laag_tot',
-                'hoofdnaam1_grondsoort', 'hoofdnaam2_grondsoort',
-                'bijmenging1_plaatselijk', 'bijmenging1_hoeveelheid',
-                'bijmenging1_grondsoort', 'bijmenging2_plaatselijk',
-                'bijmenging2_hoeveelheid', 'bijmenging2_grondsoort',
-                'bijmenging3_plaatselijk', 'bijmenging3_hoeveelheid',
-                'bijmenging3_grondsoort']
+    df_default_columns = ['pkey_interpretatie', 'pkey_boring',
+                          'betrouwbaarheid_interpretatie', 'x', 'y',
+                          'diepte_laag_van', 'diepte_laag_tot',
+                          'hoofdnaam1_grondsoort', 'hoofdnaam2_grondsoort',
+                          'bijmenging1_plaatselijk', 'bijmenging1_hoeveelheid',
+                          'bijmenging1_grondsoort', 'bijmenging2_plaatselijk',
+                          'bijmenging2_hoeveelheid', 'bijmenging2_grondsoort',
+                          'bijmenging3_plaatselijk', 'bijmenging3_hoeveelheid',
+                          'bijmenging3_grondsoort']
 
     def test_search_nan(self, mp_wfs, mp_get_schema,
                         mp_remote_describefeaturetype, mp_remote_md,
@@ -101,8 +89,8 @@ class TestGecodeerdeLithologieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single())
+        df = self.search_instance.search(
+            query=self.valid_query_single)
 
     def test_search_customreturnfields(self, mp_get_schema,
                                        mp_remote_describefeaturetype,
@@ -123,8 +111,8 @@ class TestGecodeerdeLithologieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'pkey_boring'))
 
         assert type(df) is DataFrame
@@ -153,8 +141,8 @@ class TestGecodeerdeLithologieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'diepte_laag_tot'))
 
         assert df.diepte_laag_tot[0] == 4.
@@ -178,8 +166,8 @@ class TestGecodeerdeLithologieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie',
                            'hoofdnaam1_grondsoort',
                            'hoofdnaam2_grondsoort',

--- a/tests/test_search_itp_geotechnischecodering.py
+++ b/tests/test_search_itp_geotechnischecodering.py
@@ -1,31 +1,19 @@
 """Module grouping tests for the interpretaties search module."""
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
+from owslib.fes import PropertyIsEqualTo
 from pandas import DataFrame
 
 import pydov
-from owslib.fes import PropertyIsEqualTo
 from pydov.search.interpretaties import GeotechnischeCoderingSearch
 from pydov.types.interpretaties import GeotechnischeCodering
-from tests.abstract import (
-    AbstractTestSearch,
-)
-
-from tests.test_search import (
-    mp_wfs,
-    wfs,
-    mp_get_schema,
-    mp_remote_md,
-    mp_remote_fc,
-    mp_remote_describefeaturetype,
-    mp_remote_wfs_feature,
-    mp_remote_xsd,
-    mp_dov_xml,
-    mp_dov_xml_broken,
-    wfs_getfeature,
-    wfs_feature,
-)
+from tests.abstract import AbstractTestSearch
+from tests.test_search import (mp_dov_xml, mp_dov_xml_broken, mp_get_schema,
+                               mp_remote_describefeaturetype, mp_remote_fc,
+                               mp_remote_md, mp_remote_wfs_feature,
+                               mp_remote_xsd, mp_wfs, wfs, wfs_feature,
+                               wfs_getfeature)
 
 location_md_metadata = \
     'tests/data/types/interpretaties/geotechnische_codering/' \
@@ -50,118 +38,34 @@ location_xsd_base = \
 
 class TestGeotechnischeCoderingSearch(AbstractTestSearch):
     def get_search_object(self):
-        """Get an instance of the search object for this type.
-
-        Returns
-        -------
-        pydov.search.interpretaties.GeotechnischeCoderingSearch
-            Instance of GeotechnischeCoderingSearch used for searching.
-
-        """
         return GeotechnischeCoderingSearch()
 
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretaties.GeotechnischeCodering
-            Class reference for the GeotechnischeCodering class.
-
-        """
         return GeotechnischeCodering
 
     def get_valid_query_single(self):
-        """Get a valid query returning a single feature.
-
-        Returns
-        -------
-        owslib.fes.OgcExpression
-            OGC expression of the query.
-
-        """
         return PropertyIsEqualTo(propertyname='Proefnummer',
                                  literal='GEO-15/139-B1')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
 
     def get_wfs_field(self):
-        """Get the name of a WFS field.
-
-        Returns
-        -------
-        str
-            The name of the WFS field.
-
-        """
         return 'Proefnummer'
 
     def get_xml_field(self):
-        """Get the name of a field defined in XML only.
-
-        Returns
-        -------
-        str
-            The name of the XML field.
-
-        """
         return 'grondsoort'
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_valid_returnfields_extra(self):
-        """Get a list of valid return fields, including extra WFS only
-        fields not present in the default dataframe.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including extra fields
-            from WFS, not present in the default dataframe.
-
-        """
         return ('pkey_interpretatie', 'gemeente')
 
     def get_df_default_columns(self):
-        """Get a list of the column names (and order) from the default
-        dataframe.
-
-        Returns
-        -------
-        list
-            A list of the column names of the default dataframe.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y',
                 'diepte_laag_van', 'diepte_laag_tot',

--- a/tests/test_search_itp_geotechnischecodering.py
+++ b/tests/test_search_itp_geotechnischecodering.py
@@ -37,45 +37,33 @@ location_xsd_base = \
 
 
 class TestGeotechnischeCoderingSearch(AbstractTestSearch):
-    def get_search_object(self):
-        return GeotechnischeCoderingSearch()
 
-    def get_type(self):
-        return GeotechnischeCodering
+    search_instance = GeotechnischeCoderingSearch()
+    datatype_class = GeotechnischeCodering
 
-    def get_valid_query_single(self):
-        return PropertyIsEqualTo(propertyname='Proefnummer',
-                                 literal='GEO-15/139-B1')
+    valid_query_single = PropertyIsEqualTo(propertyname='Proefnummer',
+                                           literal='GEO-15/139-B1')
 
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'
+    wfs_field = 'Proefnummer'
+    xml_field = 'grondsoort'
 
-    def get_wfs_field(self):
-        return 'Proefnummer'
+    valid_returnfields = ('pkey_interpretatie',
+                          'betrouwbaarheid_interpretatie')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
+    valid_returnfields_extra = ('pkey_interpretatie', 'gemeente')
 
-    def get_xml_field(self):
-        return 'grondsoort'
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_valid_returnfields_extra(self):
-        return ('pkey_interpretatie', 'gemeente')
-
-    def get_df_default_columns(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y',
-                'diepte_laag_van', 'diepte_laag_tot',
-                'hoofdnaam1_grondsoort', 'hoofdnaam2_grondsoort',
-                'bijmenging1_plaatselijk', 'bijmenging1_hoeveelheid',
-                'bijmenging1_grondsoort',
-                'bijmenging2_plaatselijk', 'bijmenging2_hoeveelheid',
-                'bijmenging2_grondsoort',
-                'bijmenging3_plaatselijk', 'bijmenging3_hoeveelheid',
-                'bijmenging3_grondsoort']
+    df_default_columns = ['pkey_interpretatie', 'pkey_boring',
+                          'betrouwbaarheid_interpretatie', 'x', 'y',
+                          'diepte_laag_van', 'diepte_laag_tot',
+                          'hoofdnaam1_grondsoort', 'hoofdnaam2_grondsoort',
+                          'bijmenging1_plaatselijk', 'bijmenging1_hoeveelheid',
+                          'bijmenging1_grondsoort',
+                          'bijmenging2_plaatselijk', 'bijmenging2_hoeveelheid',
+                          'bijmenging2_grondsoort',
+                          'bijmenging3_plaatselijk', 'bijmenging3_hoeveelheid',
+                          'bijmenging3_grondsoort']
 
     def test_search_nan(self, mp_wfs, mp_get_schema,
                         mp_remote_describefeaturetype, mp_remote_md,
@@ -102,8 +90,8 @@ class TestGeotechnischeCoderingSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single())
+        df = self.search_instance.search(
+            query=self.valid_query_single)
 
     def test_search_customreturnfields(self, mp_get_schema,
                                        mp_remote_describefeaturetype,
@@ -124,8 +112,8 @@ class TestGeotechnischeCoderingSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'pkey_boring'))
 
         assert type(df) is DataFrame
@@ -154,8 +142,8 @@ class TestGeotechnischeCoderingSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'diepte_laag_tot'))
 
         assert df.diepte_laag_tot[0] == 2.0
@@ -179,8 +167,8 @@ class TestGeotechnischeCoderingSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie',
                            'hoofdnaam1_grondsoort',
                            'hoofdnaam2_grondsoort',

--- a/tests/test_search_itp_hydrogeologischestratigrafie.py
+++ b/tests/test_search_itp_hydrogeologischestratigrafie.py
@@ -37,39 +37,27 @@ location_xsd_base = \
 
 
 class TestHydrogeologischeStratigrafieSearch(AbstractTestSearch):
-    def get_search_object(self):
-        return HydrogeologischeStratigrafieSearch()
 
-    def get_type(self):
-        return HydrogeologischeStratigrafie
+    search_instance = HydrogeologischeStratigrafieSearch()
+    datatype_class = HydrogeologischeStratigrafie
 
-    def get_valid_query_single(self):
-        return PropertyIsEqualTo(propertyname='Proefnummer',
-                                 literal='GEO-74/254-b1')
+    valid_query_single = PropertyIsEqualTo(propertyname='Proefnummer',
+                                           literal='GEO-74/254-b1')
 
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'
+    wfs_field = 'Proefnummer'
+    xml_field = 'aquifer'
 
-    def get_wfs_field(self):
-        return 'Proefnummer'
+    valid_returnfields = ('pkey_interpretatie',
+                          'betrouwbaarheid_interpretatie')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
+    valid_returnfields_extra = ('pkey_interpretatie', 'gemeente')
 
-    def get_xml_field(self):
-        return 'aquifer'
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_valid_returnfields_extra(self):
-        return ('pkey_interpretatie', 'gemeente')
-
-    def get_df_default_columns(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y',
-                'diepte_laag_van', 'diepte_laag_tot',
-                'aquifer']
+    df_default_columns = ['pkey_interpretatie', 'pkey_boring',
+                          'betrouwbaarheid_interpretatie', 'x', 'y',
+                          'diepte_laag_van', 'diepte_laag_tot',
+                          'aquifer']
 
     def test_search_nan(self, mp_wfs, mp_get_schema,
                         mp_remote_describefeaturetype, mp_remote_md,
@@ -96,8 +84,8 @@ class TestHydrogeologischeStratigrafieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single())
+        df = self.search_instance.search(
+            query=self.valid_query_single)
 
     def test_search_customreturnfields(self, mp_get_schema,
                                        mp_remote_describefeaturetype,
@@ -118,8 +106,8 @@ class TestHydrogeologischeStratigrafieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'pkey_boring'))
 
         assert type(df) is DataFrame
@@ -148,8 +136,8 @@ class TestHydrogeologischeStratigrafieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'diepte_laag_tot'))
 
         assert df.diepte_laag_tot[0] == 2.5

--- a/tests/test_search_itp_hydrogeologischestratigrafie.py
+++ b/tests/test_search_itp_hydrogeologischestratigrafie.py
@@ -1,31 +1,19 @@
 """Module grouping tests for the interpretaties search module."""
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
+from owslib.fes import PropertyIsEqualTo
 from pandas import DataFrame
 
 import pydov
-from owslib.fes import PropertyIsEqualTo
 from pydov.search.interpretaties import HydrogeologischeStratigrafieSearch
 from pydov.types.interpretaties import HydrogeologischeStratigrafie
-from tests.abstract import (
-    AbstractTestSearch,
-)
-
-from tests.test_search import (
-    mp_wfs,
-    wfs,
-    mp_get_schema,
-    mp_remote_md,
-    mp_remote_fc,
-    mp_remote_describefeaturetype,
-    mp_remote_wfs_feature,
-    mp_remote_xsd,
-    mp_dov_xml,
-    mp_dov_xml_broken,
-    wfs_getfeature,
-    wfs_feature,
-)
+from tests.abstract import AbstractTestSearch
+from tests.test_search import (mp_dov_xml, mp_dov_xml_broken, mp_get_schema,
+                               mp_remote_describefeaturetype, mp_remote_fc,
+                               mp_remote_md, mp_remote_wfs_feature,
+                               mp_remote_xsd, mp_wfs, wfs, wfs_feature,
+                               wfs_getfeature)
 
 location_md_metadata = \
     'tests/data/types/interpretaties/hydrogeologische_stratigrafie/' \
@@ -50,118 +38,34 @@ location_xsd_base = \
 
 class TestHydrogeologischeStratigrafieSearch(AbstractTestSearch):
     def get_search_object(self):
-        """Get an instance of the search object for this type.
-
-        Returns
-        -------
-        pydov.search.interpretaties.HydrogeologischeStratigrafieSearch
-            Instance of HydrogeologischeStratigrafieSearch used for searching.
-
-        """
         return HydrogeologischeStratigrafieSearch()
 
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretaties.HydrogeologischeStratigrafie
-            Class reference for the HydrogeologischeStratigrafie class.
-
-        """
         return HydrogeologischeStratigrafie
 
     def get_valid_query_single(self):
-        """Get a valid query returning a single feature.
-
-        Returns
-        -------
-        owslib.fes.OgcExpression
-            OGC expression of the query.
-
-        """
         return PropertyIsEqualTo(propertyname='Proefnummer',
                                  literal='GEO-74/254-b1')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
 
     def get_wfs_field(self):
-        """Get the name of a WFS field.
-
-        Returns
-        -------
-        str
-            The name of the WFS field.
-
-        """
         return 'Proefnummer'
 
     def get_xml_field(self):
-        """Get the name of a field defined in XML only.
-
-        Returns
-        -------
-        str
-            The name of the XML field.
-
-        """
         return 'aquifer'
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_valid_returnfields_extra(self):
-        """Get a list of valid return fields, including extra WFS only
-        fields not present in the default dataframe.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including extra fields
-            from WFS, not present in the default dataframe.
-
-        """
         return ('pkey_interpretatie', 'gemeente')
 
     def get_df_default_columns(self):
-        """Get a list of the column names (and order) from the default
-        dataframe.
-
-        Returns
-        -------
-        list
-            A list of the column names of the default dataframe.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y',
                 'diepte_laag_van', 'diepte_laag_tot',

--- a/tests/test_search_itp_informelehydrogeologischestratigrafie.py
+++ b/tests/test_search_itp_informelehydrogeologischestratigrafie.py
@@ -42,39 +42,27 @@ location_xsd_base = \
 
 
 class TestInformeleHydrogeologischeStratigrafieSearch(AbstractTestSearch):
-    def get_search_object(self):
-        return InformeleHydrogeologischeStratigrafieSearch()
 
-    def get_type(self):
-        return InformeleHydrogeologischeStratigrafie
+    search_instance = InformeleHydrogeologischeStratigrafieSearch()
+    datatype_class = InformeleHydrogeologischeStratigrafie
 
-    def get_valid_query_single(self):
-        return PropertyIsEqualTo(propertyname='Proefnummer',
-                                 literal='B/7-0528')
+    valid_query_single = PropertyIsEqualTo(propertyname='Proefnummer',
+                                           literal='B/7-0528')
 
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'
+    wfs_field = 'Proefnummer'
+    xml_field = 'diepte_laag_van'
 
-    def get_wfs_field(self):
-        return 'Proefnummer'
+    valid_returnfields = ('pkey_interpretatie',
+                          'betrouwbaarheid_interpretatie')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
+    valid_returnfields_extra = ('pkey_interpretatie', 'gemeente')
 
-    def get_xml_field(self):
-        return 'diepte_laag_van'
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_valid_returnfields_extra(self):
-        return ('pkey_interpretatie', 'gemeente')
-
-    def get_df_default_columns(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y',
-                'diepte_laag_van', 'diepte_laag_tot',
-                'beschrijving']
+    df_default_columns = ['pkey_interpretatie', 'pkey_boring',
+                          'betrouwbaarheid_interpretatie', 'x', 'y',
+                          'diepte_laag_van', 'diepte_laag_tot',
+                          'beschrijving']
 
     def test_search_customreturnfields(self, mp_get_schema,
                                        mp_remote_describefeaturetype,
@@ -95,8 +83,8 @@ class TestInformeleHydrogeologischeStratigrafieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'pkey_boring',
                            'gemeente'))
 
@@ -127,8 +115,8 @@ class TestInformeleHydrogeologischeStratigrafieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'diepte_laag_tot'))
 
         assert df.diepte_laag_tot[0] == 1.0

--- a/tests/test_search_itp_informelehydrogeologischestratigrafie.py
+++ b/tests/test_search_itp_informelehydrogeologischestratigrafie.py
@@ -1,37 +1,21 @@
 """Module grouping tests for the interpretaties search module."""
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
+from owslib.fes import PropertyIsEqualTo
 from pandas import DataFrame
 
 import pydov
-from owslib.fes import PropertyIsEqualTo
 from pydov.search.interpretaties import (
-    FormeleStratigrafieSearch,
-    InformeleHydrogeologischeStratigrafieSearch,
-)
-from pydov.types.interpretaties import (
-    FormeleStratigrafie,
-    InformeleHydrogeologischeStratigrafie,
-)
-from tests.abstract import (
-    AbstractTestSearch,
-)
-
-from tests.test_search import (
-    mp_wfs,
-    wfs,
-    mp_get_schema,
-    mp_remote_md,
-    mp_remote_fc,
-    mp_remote_describefeaturetype,
-    mp_remote_wfs_feature,
-    mp_remote_xsd,
-    mp_dov_xml,
-    mp_dov_xml_broken,
-    wfs_getfeature,
-    wfs_feature,
-)
+    FormeleStratigrafieSearch, InformeleHydrogeologischeStratigrafieSearch)
+from pydov.types.interpretaties import (FormeleStratigrafie,
+                                        InformeleHydrogeologischeStratigrafie)
+from tests.abstract import AbstractTestSearch
+from tests.test_search import (mp_dov_xml, mp_dov_xml_broken, mp_get_schema,
+                               mp_remote_describefeaturetype, mp_remote_fc,
+                               mp_remote_md, mp_remote_wfs_feature,
+                               mp_remote_xsd, mp_wfs, wfs, wfs_feature,
+                               wfs_getfeature)
 
 location_md_metadata = \
     'tests/data/types/interpretaties/informele_hydrogeologische_stratigrafie' \
@@ -59,119 +43,34 @@ location_xsd_base = \
 
 class TestInformeleHydrogeologischeStratigrafieSearch(AbstractTestSearch):
     def get_search_object(self):
-        """Get an instance of the search object for this type.
-
-        Returns
-        -------
-        pydov.search.interpretaties.InformeleHydrogeologischeStratigrafieSearch
-            Instance of InformeleHydrogeologischeStratigrafieSearch used for
-            searching.
-
-        """
         return InformeleHydrogeologischeStratigrafieSearch()
 
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretaties.FormeleStratigrafie
-            Class reference for the FormeleStratigrafie class.
-
-        """
         return InformeleHydrogeologischeStratigrafie
 
     def get_valid_query_single(self):
-        """Get a valid query returning a single feature.
-
-        Returns
-        -------
-        owslib.fes.OgcExpression
-            OGC expression of the query.
-
-        """
         return PropertyIsEqualTo(propertyname='Proefnummer',
                                  literal='B/7-0528')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
 
     def get_wfs_field(self):
-        """Get the name of a WFS field.
-
-        Returns
-        -------
-        str
-            The name of the WFS field.
-
-        """
         return 'Proefnummer'
 
     def get_xml_field(self):
-        """Get the name of a field defined in XML only.
-
-        Returns
-        -------
-        str
-            The name of the XML field.
-
-        """
         return 'diepte_laag_van'
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_valid_returnfields_extra(self):
-        """Get a list of valid return fields, including extra WFS only
-        fields not present in the default dataframe.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including extra fields
-            from WFS, not present in the default dataframe.
-
-        """
         return ('pkey_interpretatie', 'gemeente')
 
     def get_df_default_columns(self):
-        """Get a list of the column names (and order) from the default
-        dataframe.
-
-        Returns
-        -------
-        list
-            A list of the column names of the default dataframe.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y',
                 'diepte_laag_van', 'diepte_laag_tot',

--- a/tests/test_search_itp_informelestratigrafie.py
+++ b/tests/test_search_itp_informelestratigrafie.py
@@ -1,31 +1,19 @@
 """Module grouping tests for the interpretaties search module."""
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
+from owslib.fes import PropertyIsEqualTo
 from pandas import DataFrame
 
 import pydov
-from owslib.fes import PropertyIsEqualTo
 from pydov.search.interpretaties import InformeleStratigrafieSearch
 from pydov.types.interpretaties import InformeleStratigrafie
-from tests.abstract import (
-    AbstractTestSearch,
-)
-
-from tests.test_search import (
-    mp_wfs,
-    wfs,
-    mp_get_schema,
-    mp_remote_md,
-    mp_remote_fc,
-    mp_remote_describefeaturetype,
-    mp_remote_wfs_feature,
-    mp_remote_xsd,
-    mp_dov_xml,
-    mp_dov_xml_broken,
-    wfs_getfeature,
-    wfs_feature,
-)
+from tests.abstract import AbstractTestSearch
+from tests.test_search import (mp_dov_xml, mp_dov_xml_broken, mp_get_schema,
+                               mp_remote_describefeaturetype, mp_remote_fc,
+                               mp_remote_md, mp_remote_wfs_feature,
+                               mp_remote_xsd, mp_wfs, wfs, wfs_feature,
+                               wfs_getfeature)
 
 location_md_metadata = \
     'tests/data/types/interpretaties/informele_stratigrafie/md_metadata.xml'
@@ -46,118 +34,34 @@ location_xsd_base = \
 
 class TestInformeleStratigrafieSearch(AbstractTestSearch):
     def get_search_object(self):
-        """Get an instance of the search object for this type.
-
-        Returns
-        -------
-        pydov.search.interpretaties.InformeleStratigrafieSearch
-            Instance of InformeleStratigrafieSearch used for searching.
-
-        """
         return InformeleStratigrafieSearch()
 
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretaties.InformeleStratigrafie
-            Class reference for the InformeleStratigrafie class.
-
-        """
         return InformeleStratigrafie
 
     def get_valid_query_single(self):
-        """Get a valid query returning a single feature.
-
-        Returns
-        -------
-        owslib.fes.OgcExpression
-            OGC expression of the query.
-
-        """
         return PropertyIsEqualTo(propertyname='Proefnummer',
                                  literal='kb21d54e-B45')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
 
     def get_xml_field(self):
-        """Get the name of a field defined in XML only.
-
-        Returns
-        -------
-        str
-            The name of the XML field.
-
-        """
         return 'diepte_laag_van'
 
     def get_wfs_field(self):
-        """Get the name of a WFS field.
-
-        Returns
-        -------
-        str
-            The name of the WFS field.
-
-        """
         return 'Proefnummer'
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_valid_returnfields_extra(self):
-        """Get a list of valid return fields, including extra WFS only
-        fields not present in the default dataframe.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including extra fields
-            from WFS, not present in the default dataframe.
-
-        """
         return ('pkey_interpretatie', 'gemeente')
 
     def get_df_default_columns(self):
-        """Get a list of the column names (and order) from the default
-        dataframe.
-
-        Returns
-        -------
-        list
-            A list of the column names of the default dataframe.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'pkey_sondering',
                 'betrouwbaarheid_interpretatie', 'x', 'y',

--- a/tests/test_search_itp_informelestratigrafie.py
+++ b/tests/test_search_itp_informelestratigrafie.py
@@ -33,40 +33,28 @@ location_xsd_base = \
 
 
 class TestInformeleStratigrafieSearch(AbstractTestSearch):
-    def get_search_object(self):
-        return InformeleStratigrafieSearch()
 
-    def get_type(self):
-        return InformeleStratigrafie
+    search_instance = InformeleStratigrafieSearch()
+    datatype_class = InformeleStratigrafie
 
-    def get_valid_query_single(self):
-        return PropertyIsEqualTo(propertyname='Proefnummer',
-                                 literal='kb21d54e-B45')
+    valid_query_single = PropertyIsEqualTo(propertyname='Proefnummer',
+                                           literal='kb21d54e-B45')
 
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'
+    wfs_field = 'Proefnummer'
+    xml_field = 'diepte_laag_van'
 
-    def get_xml_field(self):
-        return 'diepte_laag_van'
+    valid_returnfields = ('pkey_interpretatie',
+                          'betrouwbaarheid_interpretatie')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
+    valid_returnfields_extra = ('pkey_interpretatie', 'gemeente')
 
-    def get_wfs_field(self):
-        return 'Proefnummer'
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_valid_returnfields_extra(self):
-        return ('pkey_interpretatie', 'gemeente')
-
-    def get_df_default_columns(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'pkey_sondering',
-                'betrouwbaarheid_interpretatie', 'x', 'y',
-                'diepte_laag_van', 'diepte_laag_tot',
-                'beschrijving']
+    df_default_columns = ['pkey_interpretatie', 'pkey_boring',
+                          'pkey_sondering',
+                          'betrouwbaarheid_interpretatie', 'x', 'y',
+                          'diepte_laag_van', 'diepte_laag_tot',
+                          'beschrijving']
 
     def test_search_nan(self, mp_wfs, mp_get_schema,
                         mp_remote_describefeaturetype, mp_remote_md,
@@ -93,8 +81,8 @@ class TestInformeleStratigrafieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single())
+        df = self.search_instance.search(
+            query=self.valid_query_single)
 
         assert df.pkey_sondering.hasnans
 
@@ -117,8 +105,8 @@ class TestInformeleStratigrafieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'pkey_boring',
                            'pkey_sondering'))
 
@@ -150,8 +138,8 @@ class TestInformeleStratigrafieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'diepte_laag_tot'))
 
         assert df.diepte_laag_tot[0] == 15.5

--- a/tests/test_search_itp_lithologischebeschrijvingen.py
+++ b/tests/test_search_itp_lithologischebeschrijvingen.py
@@ -1,31 +1,19 @@
 """Module grouping tests for the interpretaties search module."""
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
+from owslib.fes import PropertyIsEqualTo
 from pandas import DataFrame
 
 import pydov
-from owslib.fes import PropertyIsEqualTo
 from pydov.search.interpretaties import LithologischeBeschrijvingenSearch
 from pydov.types.interpretaties import LithologischeBeschrijvingen
-from tests.abstract import (
-    AbstractTestSearch,
-)
-
-from tests.test_search import (
-    mp_wfs,
-    wfs,
-    mp_get_schema,
-    mp_remote_md,
-    mp_remote_fc,
-    mp_remote_describefeaturetype,
-    mp_remote_wfs_feature,
-    mp_remote_xsd,
-    mp_dov_xml,
-    mp_dov_xml_broken,
-    wfs_getfeature,
-    wfs_feature,
-)
+from tests.abstract import AbstractTestSearch
+from tests.test_search import (mp_dov_xml, mp_dov_xml_broken, mp_get_schema,
+                               mp_remote_describefeaturetype, mp_remote_fc,
+                               mp_remote_md, mp_remote_wfs_feature,
+                               mp_remote_xsd, mp_wfs, wfs, wfs_feature,
+                               wfs_getfeature)
 
 location_md_metadata = \
     'tests/data/types/interpretaties/lithologische_beschrijvingen/' \
@@ -50,118 +38,34 @@ location_xsd_base = \
 
 class TestLithologischeBeschrijvingenSearch(AbstractTestSearch):
     def get_search_object(self):
-        """Get an instance of the search object for this type.
-
-        Returns
-        -------
-        pydov.search.interpretaties.LithologischeBeschrijvingenSearch
-            Instance of LithologischeBeschrijvingenSearch used for searching.
-
-        """
         return LithologischeBeschrijvingenSearch()
 
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretaties.LithologischeBeschrijvingen
-            Class reference for the LithologischeBeschrijvingen class.
-
-        """
         return LithologischeBeschrijvingen
 
     def get_valid_query_single(self):
-        """Get a valid query returning a single feature.
-
-        Returns
-        -------
-        owslib.fes.OgcExpression
-            OGC expression of the query.
-
-        """
         return PropertyIsEqualTo(propertyname='Proefnummer',
                                  literal='kb15d28w-B345')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
 
     def get_wfs_field(self):
-        """Get the name of a WFS field.
-
-        Returns
-        -------
-        str
-            The name of the WFS field.
-
-        """
         return 'Proefnummer'
 
     def get_xml_field(self):
-        """Get the name of a field defined in XML only.
-
-        Returns
-        -------
-        str
-            The name of the XML field.
-
-        """
         return 'beschrijving'
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_valid_returnfields_extra(self):
-        """Get a list of valid return fields, including extra WFS only
-        fields not present in the default dataframe.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including extra fields
-            from WFS, not present in the default dataframe.
-
-        """
         return ('pkey_interpretatie', 'gemeente')
 
     def get_df_default_columns(self):
-        """Get a list of the column names (and order) from the default
-        dataframe.
-
-        Returns
-        -------
-        list
-            A list of the column names of the default dataframe.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y', 'diepte_laag_van',
                 'diepte_laag_tot', 'beschrijving']

--- a/tests/test_search_itp_lithologischebeschrijvingen.py
+++ b/tests/test_search_itp_lithologischebeschrijvingen.py
@@ -37,38 +37,27 @@ location_xsd_base = \
 
 
 class TestLithologischeBeschrijvingenSearch(AbstractTestSearch):
-    def get_search_object(self):
-        return LithologischeBeschrijvingenSearch()
 
-    def get_type(self):
-        return LithologischeBeschrijvingen
+    search_instance = LithologischeBeschrijvingenSearch()
+    datatype_class = LithologischeBeschrijvingen
 
-    def get_valid_query_single(self):
-        return PropertyIsEqualTo(propertyname='Proefnummer',
-                                 literal='kb15d28w-B345')
+    valid_query_single = PropertyIsEqualTo(propertyname='Proefnummer',
+                                           literal='kb15d28w-B345')
 
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'
+    wfs_field = 'Proefnummer'
+    xml_field = 'beschrijving'
 
-    def get_wfs_field(self):
-        return 'Proefnummer'
+    valid_returnfields = ('pkey_interpretatie',
+                          'betrouwbaarheid_interpretatie')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
+    valid_returnfields_extra = ('pkey_interpretatie', 'gemeente')
 
-    def get_xml_field(self):
-        return 'beschrijving'
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_valid_returnfields_extra(self):
-        return ('pkey_interpretatie', 'gemeente')
-
-    def get_df_default_columns(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y', 'diepte_laag_van',
-                'diepte_laag_tot', 'beschrijving']
+    df_default_columns = [
+        'pkey_interpretatie', 'pkey_boring',
+        'betrouwbaarheid_interpretatie', 'x', 'y', 'diepte_laag_van',
+        'diepte_laag_tot', 'beschrijving']
 
     def test_search_customreturnfields(self, mp_get_schema,
                                        mp_remote_describefeaturetype,
@@ -89,8 +78,8 @@ class TestLithologischeBeschrijvingenSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'pkey_boring')
         )
 
@@ -118,8 +107,8 @@ class TestLithologischeBeschrijvingenSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'diepte_laag_tot'))
 
         assert df.diepte_laag_tot[0] == 1

--- a/tests/test_search_itp_quartairstratigrafie.py
+++ b/tests/test_search_itp_quartairstratigrafie.py
@@ -1,31 +1,19 @@
 """Module grouping tests for the interpretaties search module."""
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
+from owslib.fes import PropertyIsEqualTo
 from pandas import DataFrame
 
 import pydov
-from owslib.fes import PropertyIsEqualTo
 from pydov.search.interpretaties import QuartairStratigrafieSearch
 from pydov.types.interpretaties import QuartairStratigrafie
-from tests.abstract import (
-    AbstractTestSearch,
-)
-
-from tests.test_search import (
-    mp_wfs,
-    wfs,
-    mp_get_schema,
-    mp_remote_md,
-    mp_remote_fc,
-    mp_remote_describefeaturetype,
-    mp_remote_wfs_feature,
-    mp_dov_xml,
-    mp_dov_xml_broken,
-    mp_remote_xsd,
-    wfs_getfeature,
-    wfs_feature,
-)
+from tests.abstract import AbstractTestSearch
+from tests.test_search import (mp_dov_xml, mp_dov_xml_broken, mp_get_schema,
+                               mp_remote_describefeaturetype, mp_remote_fc,
+                               mp_remote_md, mp_remote_wfs_feature,
+                               mp_remote_xsd, mp_wfs, wfs, wfs_feature,
+                               wfs_getfeature)
 
 location_md_metadata = \
     'tests/data/types/interpretaties/quartaire_stratigrafie/md_metadata.xml'
@@ -45,118 +33,34 @@ location_xsd_base = \
 
 class TestQuartairStratigrafieSearch(AbstractTestSearch):
     def get_search_object(self):
-        """Get an instance of the search object for this type.
-
-        Returns
-        -------
-        pydov.search.interpretaties.QuartairStratigrafieSearch
-            Instance of QuartairStratigrafieSearch used for searching.
-
-        """
         return QuartairStratigrafieSearch()
 
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretaties.QuartairStratigrafie
-            Class reference for the QuartairStratigrafie class.
-
-        """
         return QuartairStratigrafie
 
     def get_valid_query_single(self):
-        """Get a valid query returning a single feature.
-
-        Returns
-        -------
-        owslib.fes.OgcExpression
-            OGC expression of the query.
-
-        """
         return PropertyIsEqualTo(propertyname='Proefnummer',
                                  literal='GEO-42/190-B14')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
 
     def get_wfs_field(self):
-        """Get the name of a WFS field.
-
-        Returns
-        -------
-        str
-            The name of the WFS field.
-
-        """
         return 'Proefnummer'
 
     def get_xml_field(self):
-        """Get the name of a field defined in XML only.
-
-        Returns
-        -------
-        str
-            The name of the XML field.
-
-        """
         return 'diepte_laag_van'
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_valid_returnfields_extra(self):
-        """Get a list of valid return fields, including extra WFS only
-        fields not present in the default dataframe.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including extra fields
-            from WFS, not present in the default dataframe.
-
-        """
         return ('pkey_interpretatie', 'gemeente')
 
     def get_df_default_columns(self):
-        """Get a list of the column names (and order) from the default
-        dataframe.
-
-        Returns
-        -------
-        list
-            A list of the column names of the default dataframe.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y',
                 'diepte_laag_van', 'diepte_laag_tot',

--- a/tests/test_search_itp_quartairstratigrafie.py
+++ b/tests/test_search_itp_quartairstratigrafie.py
@@ -32,39 +32,27 @@ location_xsd_base = \
 
 
 class TestQuartairStratigrafieSearch(AbstractTestSearch):
-    def get_search_object(self):
-        return QuartairStratigrafieSearch()
 
-    def get_type(self):
-        return QuartairStratigrafie
+    search_instance = QuartairStratigrafieSearch()
+    datatype_class = QuartairStratigrafie
 
-    def get_valid_query_single(self):
-        return PropertyIsEqualTo(propertyname='Proefnummer',
-                                 literal='GEO-42/190-B14')
+    valid_query_single = PropertyIsEqualTo(propertyname='Proefnummer',
+                                           literal='GEO-42/190-B14')
 
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'
+    wfs_field = 'Proefnummer'
+    xml_field = 'diepte_laag_van'
 
-    def get_wfs_field(self):
-        return 'Proefnummer'
+    valid_returnfields = ('pkey_interpretatie',
+                          'betrouwbaarheid_interpretatie')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
+    valid_returnfields_extra = ('pkey_interpretatie', 'gemeente')
 
-    def get_xml_field(self):
-        return 'diepte_laag_van'
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'betrouwbaarheid_interpretatie')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_valid_returnfields_extra(self):
-        return ('pkey_interpretatie', 'gemeente')
-
-    def get_df_default_columns(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y',
-                'diepte_laag_van', 'diepte_laag_tot',
-                'lid1', 'relatie_lid1_lid2', 'lid2']
+    df_default_columns = ['pkey_interpretatie', 'pkey_boring',
+                          'betrouwbaarheid_interpretatie', 'x', 'y',
+                          'diepte_laag_van', 'diepte_laag_tot',
+                          'lid1', 'relatie_lid1_lid2', 'lid2']
 
     def test_search_customreturnfields(self, mp_get_schema,
                                        mp_remote_describefeaturetype,
@@ -85,8 +73,8 @@ class TestQuartairStratigrafieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'pkey_boring',
                            ))
 
@@ -115,8 +103,8 @@ class TestQuartairStratigrafieSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_interpretatie', 'diepte_laag_tot'))
 
         assert df.diepte_laag_tot[0] == 8.0

--- a/tests/test_search_sondering.py
+++ b/tests/test_search_sondering.py
@@ -3,31 +3,19 @@ import datetime
 
 import pandas as pd
 import pytest
-
 from owslib.fes import PropertyIsEqualTo
+
 from pydov.search.boring import BoringSearch
 from pydov.search.sondering import SonderingSearch
 from pydov.types.boring import Boring
 from pydov.types.sondering import Sondering
 from pydov.util import owsutil
-from tests.abstract import (
-    AbstractTestSearch,
-)
-
-from tests.test_search import (
-    mp_wfs,
-    wfs,
-    mp_get_schema,
-    mp_remote_md,
-    mp_remote_fc,
-    mp_remote_describefeaturetype,
-    mp_remote_wfs_feature,
-    mp_remote_xsd,
-    mp_dov_xml,
-    mp_dov_xml_broken,
-    wfs_getfeature,
-    wfs_feature,
-)
+from tests.abstract import AbstractTestSearch
+from tests.test_search import (mp_dov_xml, mp_dov_xml_broken, mp_get_schema,
+                               mp_remote_describefeaturetype, mp_remote_fc,
+                               mp_remote_md, mp_remote_wfs_feature,
+                               mp_remote_xsd, mp_wfs, wfs, wfs_feature,
+                               wfs_getfeature)
 
 location_md_metadata = 'tests/data/types/sondering/md_metadata.xml'
 location_fc_featurecatalogue = \
@@ -66,119 +54,35 @@ def md_metadata(wfs, mp_remote_md):
 
 class TestSonderingSearch(AbstractTestSearch):
     def get_search_object(self):
-        """Get an instance of the search object for this type.
-
-        Returns
-        -------
-        pydov.search.boring.SonderingSearch
-            Instance of SonderingSearch used for searching.
-
-        """
         return SonderingSearch()
 
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.sondering.Sondering
-            Class reference for the Sondering class.
-
-        """
         return Sondering
 
     def get_valid_query_single(self):
-        """Get a valid query returning a single feature.
-
-        Returns
-        -------
-        owslib.fes.OgcExpression
-            OGC expression of the query.
-
-        """
         return PropertyIsEqualTo(propertyname='sondeernummer',
                                  literal='GEO-61/3075-S1')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
 
     def get_wfs_field(self):
-        """Get the name of a WFS field.
-
-        Returns
-        -------
-        str
-            The name of the WFS field.
-
-        """
         return 'sondeernummer'
 
     def get_xml_field(self):
-        """Get the name of a field defined in XML only.
-
-        Returns
-        -------
-        str
-            The name of the XML field.
-
-        """
         return 'gw_meting'
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_sondering', 'sondeernummer', 'diepte_sondering_tot',
                 'datum_aanvang')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_sondering', 'sondeernummer', 'z', 'qc', 'Qt')
 
     def get_valid_returnfields_extra(self):
-        """Get a list of valid return fields, including extra WFS only
-        fields not present in the default dataframe.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including extra fields
-            from WFS, not present in the default dataframe.
-
-        """
         return ('pkey_sondering', 'conus')
 
     def get_df_default_columns(self):
-        """Get a list of the column names (and order) from the default
-        dataframe.
-
-        Returns
-        -------
-        list
-            A list of the column names of the default dataframe.
-
-        """
         return ['pkey_sondering', 'sondeernummer', 'x', 'y',
                 'start_sondering_mtaw', 'diepte_sondering_van',
                 'diepte_sondering_tot', 'datum_aanvang', 'uitvoerder',

--- a/tests/test_search_sondering.py
+++ b/tests/test_search_sondering.py
@@ -53,41 +53,30 @@ def md_metadata(wfs, mp_remote_md):
 
 
 class TestSonderingSearch(AbstractTestSearch):
-    def get_search_object(self):
-        return SonderingSearch()
 
-    def get_type(self):
-        return Sondering
+    search_instance = SonderingSearch()
+    datatype_class = Sondering
 
-    def get_valid_query_single(self):
-        return PropertyIsEqualTo(propertyname='sondeernummer',
-                                 literal='GEO-61/3075-S1')
+    valid_query_single = PropertyIsEqualTo(propertyname='sondeernummer',
+                                           literal='GEO-61/3075-S1')
 
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'
+    wfs_field = 'sondeernummer'
+    xml_field = 'gw_meting'
 
-    def get_wfs_field(self):
-        return 'sondeernummer'
+    valid_returnfields = (
+        'pkey_sondering', 'sondeernummer', 'diepte_sondering_tot',
+                          'datum_aanvang')
+    valid_returnfields_subtype = (
+        'pkey_sondering', 'sondeernummer', 'z', 'qc', 'Qt')
+    valid_returnfields_extra = ('pkey_sondering', 'conus')
 
-    def get_xml_field(self):
-        return 'gw_meting'
-
-    def get_valid_returnfields(self):
-        return ('pkey_sondering', 'sondeernummer', 'diepte_sondering_tot',
-                'datum_aanvang')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_sondering', 'sondeernummer', 'z', 'qc', 'Qt')
-
-    def get_valid_returnfields_extra(self):
-        return ('pkey_sondering', 'conus')
-
-    def get_df_default_columns(self):
-        return ['pkey_sondering', 'sondeernummer', 'x', 'y',
-                'start_sondering_mtaw', 'diepte_sondering_van',
-                'diepte_sondering_tot', 'datum_aanvang', 'uitvoerder',
-                'sondeermethode', 'apparaat', 'datum_gw_meting',
-                'diepte_gw_m', 'z', 'qc', 'Qt', 'fs', 'u', 'i']
+    df_default_columns = [
+        'pkey_sondering', 'sondeernummer', 'x', 'y',
+        'start_sondering_mtaw', 'diepte_sondering_van',
+        'diepte_sondering_tot', 'datum_aanvang', 'uitvoerder',
+        'sondeermethode', 'apparaat', 'datum_gw_meting',
+        'diepte_gw_m', 'z', 'qc', 'Qt', 'fs', 'u', 'i']
 
     def test_search_date(self, mp_wfs, mp_get_schema,
                          mp_remote_describefeaturetype, mp_remote_md,
@@ -114,15 +103,15 @@ class TestSonderingSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single())
+        df = self.search_instance.search(
+            query=self.valid_query_single)
 
         # specific test for the Zulu time wfs 1.1.0 issue
         assert df.datum_aanvang.unique()[0] == datetime.date(2002, 12, 17)
 
         assert pd.Timestamp(
             df.datum_gw_meting.unique()[0]).to_pydatetime() == \
-               datetime.datetime(2002, 12, 17, 14, 30, 0, 0)
+            datetime.datetime(2002, 12, 17, 14, 30, 0, 0)
 
     def test_search_nan(self, mp_wfs, mp_get_schema,
                         mp_remote_describefeaturetype, mp_remote_md,
@@ -149,8 +138,8 @@ class TestSonderingSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single())
+        df = self.search_instance.search(
+            query=self.valid_query_single)
 
         assert df.Qt.hasnans
 
@@ -174,8 +163,8 @@ class TestSonderingSearch(AbstractTestSearch):
             Monkeypatch the call to get the remote XML data.
 
         """
-        df = self.get_search_object().search(
-            query=self.get_valid_query_single(),
+        df = self.search_instance.search(
+            query=self.valid_query_single,
             return_fields=('pkey_sondering', 'sondeernummer', 'diepte_gw_m'))
 
         assert df.diepte_gw_m[0] == 3.60

--- a/tests/test_types_boring.py
+++ b/tests/test_types_boring.py
@@ -3,62 +3,23 @@
 from pydov.types.boring import Boring
 from pydov.util.dovutil import build_dov_url
 from tests.abstract import AbstractTestTypes
+from tests.test_search_boring import (location_dov_xml, location_wfs_feature,
+                                      location_wfs_getfeature, mp_dov_xml,
+                                      wfs_feature, wfs_getfeature)
 
-from tests.test_search_boring import (
-    wfs_getfeature,
-    wfs_feature,
-    mp_dov_xml,
-    location_wfs_getfeature,
-    location_wfs_feature,
-    location_dov_xml,
-)
 
 class TestBoring(AbstractTestTypes):
     """Class grouping tests for the pydov.types.boring.Boring class."""
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.boring.Boring
-            Class reference for the Boring class.
-
-        """
         return Boring
 
     def get_namespace(self):
-        """Get the WFS namespace associated with this datatype.
-
-        Returns
-        -------
-        str
-            WFS namespace for this type.
-
-        """
         return 'http://dov.vlaanderen.be/ocdov/dov-pub'
 
     def get_pkey_base(self):
-        """Get the base URL for the permanent keys of this datatype.
-
-        Returns
-        -------
-        str
-            Base URL for the permanent keys of this datatype. For example
-            "https://www.dov.vlaanderen.be/data/boring/"
-
-        """
         return build_dov_url('data/boring/')
 
     def get_field_names(self):
-        """Get the field names for this type as listed in the documentation in
-        docs/description_output_dataframes.rst
-
-        Returns
-        -------
-        list
-            List of field names.
-
-        """
         return ['pkey_boring', 'boornummer', 'x', 'y', 'mv_mtaw',
                 'start_boring_mtaw', 'gemeente', 'diepte_boring_van',
                 'diepte_boring_tot', 'datum_aanvang', 'uitvoerder',
@@ -66,62 +27,19 @@ class TestBoring(AbstractTestTypes):
                 'diepte_methode_tot', 'boormethode']
 
     def get_field_names_subtypes(self):
-        """Get the field names of this type that originate from subtypes only.
-
-        Returns
-        -------
-        list<str>
-            List of field names from subtypes.
-
-        """
         return ['diepte_methode_van', 'diepte_methode_tot', 'boormethode']
 
     def get_field_names_nosubtypes(self):
-        """Get the field names for this type, without including fields from
-        subtypes.
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
         return ['pkey_boring', 'boornummer', 'x', 'y', 'mv_mtaw',
                 'start_boring_mtaw', 'gemeente', 'diepte_boring_van',
                 'diepte_boring_tot', 'datum_aanvang', 'uitvoerder',
                 'boorgatmeting']
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_boring', 'diepte_boring_tot')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_boring', 'diepte_methode_van', 'boormethode')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
-

--- a/tests/test_types_boring.py
+++ b/tests/test_types_boring.py
@@ -10,36 +10,28 @@ from tests.test_search_boring import (location_dov_xml, location_wfs_feature,
 
 class TestBoring(AbstractTestTypes):
     """Class grouping tests for the pydov.types.boring.Boring class."""
-    def get_type(self):
-        return Boring
 
-    def get_namespace(self):
-        return 'http://dov.vlaanderen.be/ocdov/dov-pub'
+    datatype_class = Boring
+    namespace = 'http://dov.vlaanderen.be/ocdov/dov-pub'
+    pkey_base = build_dov_url('data/boring/')
 
-    def get_pkey_base(self):
-        return build_dov_url('data/boring/')
+    field_names = [
+        'pkey_boring', 'boornummer', 'x', 'y', 'mv_mtaw',
+        'start_boring_mtaw', 'gemeente', 'diepte_boring_van',
+        'diepte_boring_tot', 'datum_aanvang', 'uitvoerder',
+        'boorgatmeting', 'diepte_methode_van',
+        'diepte_methode_tot', 'boormethode']
+    field_names_subtypes = [
+        'diepte_methode_van',
+        'diepte_methode_tot', 'boormethode']
+    field_names_nosubtypes = [
+        'pkey_boring', 'boornummer', 'x', 'y', 'mv_mtaw',
+        'start_boring_mtaw', 'gemeente', 'diepte_boring_van',
+        'diepte_boring_tot', 'datum_aanvang', 'uitvoerder',
+        'boorgatmeting']
 
-    def get_field_names(self):
-        return ['pkey_boring', 'boornummer', 'x', 'y', 'mv_mtaw',
-                'start_boring_mtaw', 'gemeente', 'diepte_boring_van',
-                'diepte_boring_tot', 'datum_aanvang', 'uitvoerder',
-                'boorgatmeting', 'diepte_methode_van',
-                'diepte_methode_tot', 'boormethode']
+    valid_returnfields = ('pkey_boring', 'diepte_boring_tot')
+    valid_returnfields_subtype = (
+        'pkey_boring', 'diepte_methode_van', 'boormethode')
 
-    def get_field_names_subtypes(self):
-        return ['diepte_methode_van', 'diepte_methode_tot', 'boormethode']
-
-    def get_field_names_nosubtypes(self):
-        return ['pkey_boring', 'boornummer', 'x', 'y', 'mv_mtaw',
-                'start_boring_mtaw', 'gemeente', 'diepte_boring_van',
-                'diepte_boring_tot', 'datum_aanvang', 'uitvoerder',
-                'boorgatmeting']
-
-    def get_valid_returnfields(self):
-        return ('pkey_boring', 'diepte_boring_tot')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_boring', 'diepte_methode_van', 'boormethode')
-
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'

--- a/tests/test_types_grondmonster.py
+++ b/tests/test_types_grondmonster.py
@@ -3,62 +3,25 @@
 from pydov.types.grondmonster import Grondmonster
 from pydov.util.dovutil import build_dov_url
 from tests.abstract import AbstractTestTypes
+from tests.test_search_grondmonster import (location_dov_xml,
+                                            location_wfs_feature,
+                                            location_wfs_getfeature,
+                                            mp_dov_xml, wfs_feature,
+                                            wfs_getfeature)
 
-from tests.test_search_grondmonster import (
-    wfs_getfeature,
-    wfs_feature,
-    mp_dov_xml,
-    location_wfs_getfeature,
-    location_wfs_feature,
-    location_dov_xml,
-)
 
 class TestGrondmonster(AbstractTestTypes):
     """Class grouping tests for the pydov.types.grondmonster.Grondmonster class."""
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.grondmonster.Grondmonster
-            Class reference for the Grondmonster class.
-
-        """
         return Grondmonster
 
     def get_namespace(self):
-        """Get the WFS namespace associated with this datatype.
-
-        Returns
-        -------
-        str
-            WFS namespace for this type.
-
-        """
         return 'http://dov.vlaanderen.be/ocdov/boringen'
 
     def get_pkey_base(self):
-        """Get the base URL for the permanent keys of this datatype.
-
-        Returns
-        -------
-        str
-            Base URL for the permanent keys of this datatype. For example
-            "https://www.dov.vlaanderen.be/data/grondmonster/"
-
-        """
         return build_dov_url('data/grondmonster/')
 
     def get_field_names(self):
-        """Get the field names for this type as listed in the documentation in
-        docs/description_output_dataframes.rst
-
-        Returns
-        -------
-        list
-            List of field names.
-
-        """
         return ['pkey_grondmonster', 'naam', 'pkey_boring', 'boornummer',
                 'datum', 'x', 'y', 'gemeente', 'diepte_van_m', 'diepte_tot_m',
                 'peil_van_mtaw', 'peil_tot_mtaw', 'monstertype', 'astm_naam',
@@ -68,26 +31,9 @@ class TestGrondmonster(AbstractTestTypes):
                 'diameter', 'fractie', 'methode']
 
     def get_field_names_subtypes(self):
-        """Get the field names of this type that originate from subtypes only.
-
-        Returns
-        -------
-        list<str>
-            List of field names from subtypes.
-
-        """
         return ['diepte_methode_van', 'diepte_methode_tot', 'boormethode']
 
     def get_field_names_nosubtypes(self):
-        """Get the field names for this type, without including fields from
-        subtypes.
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
         return ['pkey_grondmonster', 'naam', 'pkey_boring', 'boornummer',
                 'datum', 'x', 'y', 'gemeente', 'diepte_van_m', 'diepte_tot_m',
                 'peil_van_mtaw', 'peil_tot_mtaw', 'monstertype', 'astm_naam',
@@ -96,36 +42,10 @@ class TestGrondmonster(AbstractTestTypes):
                 'korrelvolumemassa', 'volumemassa', 'watergehalte']
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_grondmonster', 'diepte_tot_m')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('diameter', 'fractie', 'methode')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
-

--- a/tests/test_types_grondmonster.py
+++ b/tests/test_types_grondmonster.py
@@ -11,41 +11,32 @@ from tests.test_search_grondmonster import (location_dov_xml,
 
 
 class TestGrondmonster(AbstractTestTypes):
-    """Class grouping tests for the pydov.types.grondmonster.Grondmonster class."""
-    def get_type(self):
-        return Grondmonster
+    """Class grouping tests for the pydov.types.grondmonster.Grondmonster
+    class."""
 
-    def get_namespace(self):
-        return 'http://dov.vlaanderen.be/ocdov/boringen'
+    datatype_class = Grondmonster
+    namespace = 'http://dov.vlaanderen.be/ocdov/boringen'
+    pkey_base = build_dov_url('data/grondmonster/')
 
-    def get_pkey_base(self):
-        return build_dov_url('data/grondmonster/')
+    field_names = [
+        'pkey_grondmonster', 'naam', 'pkey_boring', 'boornummer',
+        'datum', 'x', 'y', 'gemeente', 'diepte_van_m', 'diepte_tot_m',
+        'peil_van_mtaw', 'peil_tot_mtaw', 'monstertype', 'astm_naam',
+        'grondsoort_bggg', 'humusgehalte', 'kalkgehalte',
+        'uitrolgrens', 'vloeigrens', 'glauconiet',
+        'korrelvolumemassa', 'volumemassa', 'watergehalte',
+        'diameter', 'fractie', 'methode']
+    field_names_subtypes = [
+        'diepte_methode_van', 'diepte_methode_tot', 'boormethode']
+    field_names_nosubtypes = [
+        'pkey_grondmonster', 'naam', 'pkey_boring', 'boornummer',
+        'datum', 'x', 'y', 'gemeente', 'diepte_van_m', 'diepte_tot_m',
+        'peil_van_mtaw', 'peil_tot_mtaw', 'monstertype', 'astm_naam',
+        'grondsoort_bggg', 'humusgehalte', 'kalkgehalte',
+        'uitrolgrens', 'vloeigrens', 'glauconiet',
+        'korrelvolumemassa', 'volumemassa', 'watergehalte']
 
-    def get_field_names(self):
-        return ['pkey_grondmonster', 'naam', 'pkey_boring', 'boornummer',
-                'datum', 'x', 'y', 'gemeente', 'diepte_van_m', 'diepte_tot_m',
-                'peil_van_mtaw', 'peil_tot_mtaw', 'monstertype', 'astm_naam',
-                'grondsoort_bggg', 'humusgehalte', 'kalkgehalte',
-                'uitrolgrens', 'vloeigrens', 'glauconiet',
-                'korrelvolumemassa', 'volumemassa', 'watergehalte',
-                'diameter', 'fractie', 'methode']
+    valid_returnfields = ('pkey_grondmonster', 'diepte_tot_m')
+    valid_returnfields_subtype = ('diameter', 'fractie', 'methode')
 
-    def get_field_names_subtypes(self):
-        return ['diepte_methode_van', 'diepte_methode_tot', 'boormethode']
-
-    def get_field_names_nosubtypes(self):
-        return ['pkey_grondmonster', 'naam', 'pkey_boring', 'boornummer',
-                'datum', 'x', 'y', 'gemeente', 'diepte_van_m', 'diepte_tot_m',
-                'peil_van_mtaw', 'peil_tot_mtaw', 'monstertype', 'astm_naam',
-                'grondsoort_bggg', 'humusgehalte', 'kalkgehalte',
-                'uitrolgrens', 'vloeigrens', 'glauconiet',
-                'korrelvolumemassa', 'volumemassa', 'watergehalte']
-
-    def get_valid_returnfields(self):
-        return ('pkey_grondmonster', 'diepte_tot_m')
-
-    def get_valid_returnfields_subtype(self):
-        return ('diameter', 'fractie', 'methode')
-
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'

--- a/tests/test_types_grondwaterfilter.py
+++ b/tests/test_types_grondwaterfilter.py
@@ -2,64 +2,26 @@
 from pydov.types.grondwaterfilter import GrondwaterFilter
 from pydov.util.dovutil import build_dov_url
 from tests.abstract import AbstractTestTypes
-
-from tests.test_search_grondwaterfilter import (
-    wfs_getfeature,
-    wfs_feature,
-    mp_dov_xml,
-    location_wfs_getfeature,
-    location_wfs_feature,
-    location_dov_xml,
-)
+from tests.test_search_grondwaterfilter import (location_dov_xml,
+                                                location_wfs_feature,
+                                                location_wfs_getfeature,
+                                                mp_dov_xml, wfs_feature,
+                                                wfs_getfeature)
 
 
 class TestGrondwaterFilter(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.grondwaterfilter.GrondwaterFilter class."""
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.grondwaterfilter.GrondwaterFilter
-            Class reference for the GrondwaterFilter class.
-
-        """
         return GrondwaterFilter
 
     def get_namespace(self):
-        """Get the WFS namespace associated with this datatype.
-
-        Returns
-        -------
-        str
-            WFS namespace for this type.
-
-        """
         return 'http://dov.vlaanderen.be/grondwater/gw_meetnetten'
 
     def get_pkey_base(self):
-        """Get the base URL for the permanent keys of this datatype.
-
-        Returns
-        -------
-        str
-            Base URL for the permanent keys of this datatype. For example
-            "https://www.dov.vlaanderen.be/data/boring/"
-
-        """
         return build_dov_url('data/filter/')
 
     def get_field_names(self):
-        """Get the field names for this type as listed in the documentation in
-        docs/description_output_dataframes.rst
-
-        Returns
-        -------
-        list
-            List of field names.
-
-        """
         return ['pkey_filter', 'pkey_grondwaterlocatie', 'gw_id',
                 'filternummer', 'filtertype', 'x', 'y',
                 'start_grondwaterlocatie_mtaw', 'mv_mtaw',
@@ -70,27 +32,10 @@ class TestGrondwaterFilter(AbstractTestTypes):
                 'betrouwbaarheid', 'methode', 'filterstatus', 'filtertoestand']
 
     def get_field_names_subtypes(self):
-        """Get the field names of this type that originate from subtypes only.
-
-        Returns
-        -------
-        list<str>
-            List of field names from subtypes.
-
-        """
         return ['datum', 'tijdstip', 'peil_mtaw', 'betrouwbaarheid',
                 'methode']
 
     def get_field_names_nosubtypes(self):
-        """Get the field names for this type, without including fields from
-        subtypes.
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
         return ['pkey_filter', 'pkey_grondwaterlocatie', 'gw_id',
                 'filternummer', 'filtertype', 'x', 'y',
                 'start_grondwaterlocatie_mtaw', 'mv_mtaw',
@@ -99,35 +44,10 @@ class TestGrondwaterFilter(AbstractTestTypes):
                 'diepte_onderkant_filter', 'lengte_filter']
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_filter', 'meetnet_code')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_filter', 'peil_mtaw')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'

--- a/tests/test_types_grondwaterfilter.py
+++ b/tests/test_types_grondwaterfilter.py
@@ -12,42 +12,32 @@ from tests.test_search_grondwaterfilter import (location_dov_xml,
 class TestGrondwaterFilter(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.grondwaterfilter.GrondwaterFilter class."""
-    def get_type(self):
-        return GrondwaterFilter
 
-    def get_namespace(self):
-        return 'http://dov.vlaanderen.be/grondwater/gw_meetnetten'
+    datatype_class = GrondwaterFilter
+    namespace = 'http://dov.vlaanderen.be/grondwater/gw_meetnetten'
+    pkey_base = build_dov_url('data/filter/')
 
-    def get_pkey_base(self):
-        return build_dov_url('data/filter/')
+    field_names = [
+        'pkey_filter', 'pkey_grondwaterlocatie', 'gw_id',
+        'filternummer', 'filtertype', 'x', 'y',
+        'start_grondwaterlocatie_mtaw', 'mv_mtaw',
+        'gemeente', 'meetnet_code', 'aquifer_code',
+        'grondwaterlichaam_code', 'regime',
+        'diepte_onderkant_filter', 'lengte_filter',
+        'datum', 'tijdstip', 'peil_mtaw',
+        'betrouwbaarheid', 'methode', 'filterstatus', 'filtertoestand']
+    field_names_subtypes = [
+        'datum', 'tijdstip', 'peil_mtaw', 'betrouwbaarheid',
+        'methode']
+    field_names_nosubtypes = [
+        'pkey_filter', 'pkey_grondwaterlocatie', 'gw_id',
+        'filternummer', 'filtertype', 'x', 'y',
+        'start_grondwaterlocatie_mtaw', 'mv_mtaw',
+        'gemeente', 'meetnet_code', 'aquifer_code',
+        'grondwaterlichaam_code', 'regime',
+        'diepte_onderkant_filter', 'lengte_filter']
 
-    def get_field_names(self):
-        return ['pkey_filter', 'pkey_grondwaterlocatie', 'gw_id',
-                'filternummer', 'filtertype', 'x', 'y',
-                'start_grondwaterlocatie_mtaw', 'mv_mtaw',
-                'gemeente', 'meetnet_code', 'aquifer_code',
-                'grondwaterlichaam_code', 'regime',
-                'diepte_onderkant_filter', 'lengte_filter',
-                'datum', 'tijdstip', 'peil_mtaw',
-                'betrouwbaarheid', 'methode', 'filterstatus', 'filtertoestand']
+    valid_returnfields = ('pkey_filter', 'meetnet_code')
+    valid_returnfields_subtype = ('pkey_filter', 'peil_mtaw')
 
-    def get_field_names_subtypes(self):
-        return ['datum', 'tijdstip', 'peil_mtaw', 'betrouwbaarheid',
-                'methode']
-
-    def get_field_names_nosubtypes(self):
-        return ['pkey_filter', 'pkey_grondwaterlocatie', 'gw_id',
-                'filternummer', 'filtertype', 'x', 'y',
-                'start_grondwaterlocatie_mtaw', 'mv_mtaw',
-                'gemeente', 'meetnet_code', 'aquifer_code',
-                'grondwaterlichaam_code', 'regime',
-                'diepte_onderkant_filter', 'lengte_filter']
-
-    def get_valid_returnfields(self):
-        return ('pkey_filter', 'meetnet_code')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_filter', 'peil_mtaw')
-
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'

--- a/tests/test_types_grondwatermonster.py
+++ b/tests/test_types_grondwatermonster.py
@@ -12,37 +12,28 @@ from tests.test_search_grondwatermonster import (location_dov_xml,
 class TestGrondwaterMonster(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.grondwaterfilter.GrondwaterFilter class."""
-    def get_type(self):
-        return GrondwaterMonster
 
-    def get_namespace(self):
-        return 'http://dov.vlaanderen.be/grondwater/gw_meetnetten'
+    datatype_class = GrondwaterMonster
+    namespace = 'http://dov.vlaanderen.be/grondwater/gw_meetnetten'
+    pkey_base = build_dov_url('data/watermonster/')
 
-    def get_pkey_base(self):
-        return build_dov_url('data/watermonster/')
+    field_names = [
+        'pkey_grondwatermonster', 'grondwatermonsternummer',
+        'pkey_grondwaterlocatie', 'gw_id', 'pkey_filter',
+        'filternummer', 'x', 'y', 'start_grondwaterlocatie_mtaw',
+        'gemeente', 'datum_monstername', 'parametergroep',
+        'parameter', 'detectie', 'waarde', 'eenheid', 'veld_labo']
+    field_names_subtypes = [
+        'parametergroep', 'parameter', 'detectie',
+        'waarde', 'eenheid', 'veld_labo']
+    field_names_nosubtypes = [
+        'pkey_grondwatermonster', 'grondwatermonsternummer',
+        'pkey_grondwaterlocatie', 'gw_id', 'pkey_filter',
+        'filternummer', 'x', 'y', 'start_grondwaterlocatie_mtaw',
+        'gemeente', 'datum_monstername']
 
-    def get_field_names(self):
-        return ['pkey_grondwatermonster', 'grondwatermonsternummer',
-                'pkey_grondwaterlocatie', 'gw_id', 'pkey_filter',
-                'filternummer', 'x', 'y', 'start_grondwaterlocatie_mtaw',
-                'gemeente', 'datum_monstername', 'parametergroep',
-                'parameter', 'detectie', 'waarde', 'eenheid', 'veld_labo']
+    valid_returnfields = ('y', 'gemeente')
+    valid_returnfields_subtype = (
+        'pkey_filter', 'pkey_grondwatermonster', 'eenheid')
 
-    def get_field_names_subtypes(self):
-        return ['parametergroep', 'parameter', 'detectie',
-                'waarde', 'eenheid', 'veld_labo']
-
-    def get_field_names_nosubtypes(self):
-        return ['pkey_grondwatermonster', 'grondwatermonsternummer',
-                'pkey_grondwaterlocatie', 'gw_id', 'pkey_filter',
-                'filternummer', 'x', 'y', 'start_grondwaterlocatie_mtaw',
-                'gemeente', 'datum_monstername']
-
-    def get_valid_returnfields(self):
-        return ('y', 'gemeente')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_filter', 'pkey_grondwatermonster', 'eenheid')
-
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'

--- a/tests/test_types_grondwatermonster.py
+++ b/tests/test_types_grondwatermonster.py
@@ -2,63 +2,26 @@
 from pydov.types.grondwatermonster import GrondwaterMonster
 from pydov.util.dovutil import build_dov_url
 from tests.abstract import AbstractTestTypes
-
-from tests.test_search_grondwatermonster import (
-    wfs_getfeature,
-    wfs_feature,
-    mp_dov_xml,
-    location_wfs_getfeature,
-    location_wfs_feature,
-    location_dov_xml,
-)
+from tests.test_search_grondwatermonster import (location_dov_xml,
+                                                 location_wfs_feature,
+                                                 location_wfs_getfeature,
+                                                 mp_dov_xml, wfs_feature,
+                                                 wfs_getfeature)
 
 
 class TestGrondwaterMonster(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.grondwaterfilter.GrondwaterFilter class."""
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.grondwatermonster.GrondwaterMonster
-            Class reference for the GrondwaterMonster class.
-
-        """
         return GrondwaterMonster
 
     def get_namespace(self):
-        """Get the WFS namespace associated with this datatype.
-
-        Returns
-        -------
-        str
-            WFS namespace for this type.
-
-        """
         return 'http://dov.vlaanderen.be/grondwater/gw_meetnetten'
 
     def get_pkey_base(self):
-        """Get the base URL for the permanent keys of this datatype.
-
-        Returns
-        -------
-        str
-            Base URL for the permanent keys of this datatype. For example
-            "https://www.dov.vlaanderen.be/data/boring/"
-
-        """
         return build_dov_url('data/watermonster/')
 
     def get_field_names(self):
-        """Get the field names for this type
-
-        Returns
-        -------
-        list
-            List of field names.
-
-        """
         return ['pkey_grondwatermonster', 'grondwatermonsternummer',
                 'pkey_grondwaterlocatie', 'gw_id', 'pkey_filter',
                 'filternummer', 'x', 'y', 'start_grondwaterlocatie_mtaw',
@@ -66,62 +29,20 @@ class TestGrondwaterMonster(AbstractTestTypes):
                 'parameter', 'detectie', 'waarde', 'eenheid', 'veld_labo']
 
     def get_field_names_subtypes(self):
-        """Get the field names of this type that originate from subtypes only.
-
-        Returns
-        -------
-        list<str>
-            List of field names from subtypes.
-
-        """
         return ['parametergroep', 'parameter', 'detectie',
                 'waarde', 'eenheid', 'veld_labo']
 
     def get_field_names_nosubtypes(self):
-        """Get the field names for this type, without including fields from
-        subtypes.
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
         return ['pkey_grondwatermonster', 'grondwatermonsternummer',
                 'pkey_grondwaterlocatie', 'gw_id', 'pkey_filter',
                 'filternummer', 'x', 'y', 'start_grondwaterlocatie_mtaw',
                 'gemeente', 'datum_monstername']
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('y', 'gemeente')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_filter', 'pkey_grondwatermonster', 'eenheid')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'

--- a/tests/test_types_itp_formelestratigrafie.py
+++ b/tests/test_types_itp_formelestratigrafie.py
@@ -3,122 +3,42 @@ pydov.types.interpretaties.FormeleStratigrafie class."""
 from pydov.types.interpretaties import FormeleStratigrafie
 from pydov.util.dovutil import build_dov_url
 from tests.abstract import AbstractTestTypes
-
-from tests.test_search_itp_formelestratigrafie import (
-    wfs_feature,
-    wfs_getfeature,
-    mp_dov_xml,
-    location_wfs_feature,
-    location_wfs_getfeature,
-    location_dov_xml,
-)
+from tests.test_search_itp_formelestratigrafie import (location_dov_xml,
+                                                       location_wfs_feature,
+                                                       location_wfs_getfeature,
+                                                       mp_dov_xml, wfs_feature,
+                                                       wfs_getfeature)
 
 
 class TestFormeleStratigrafie(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.FormeleStratigrafie class."""
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretaties.FormeleStratigrafie
-            Class reference for the FormeleStratigrafie class.
-
-        """
         return FormeleStratigrafie
 
     def get_namespace(self):
-        """Get the WFS namespace associated with this datatype.
-
-        Returns
-        -------
-        str
-            WFS namespace for this type.
-
-        """
         return 'http://dov.vlaanderen.be/ocdov/interpretaties'
 
     def get_pkey_base(self):
-        """Get the base URL for the permanent keys of this datatype.
-
-        Returns
-        -------
-        str
-            Base URL for the permanent keys of this datatype. For example
-            "https://www.dov.vlaanderen.be/data/interpretatie/"
-
-        """
         return build_dov_url('data/interpretatie/')
 
     def get_field_names(self):
-        """Get the field names for this type as listed in the documentation in
-        docs/description_output_dataframes.rst
-
-        Returns
-        -------
-        list
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'pkey_sondering', 'betrouwbaarheid_interpretatie', 'x', 'y',
                 'diepte_laag_van', 'diepte_laag_tot', 'lid1', 'relatie_lid1_lid2', 'lid2']
 
     def get_field_names_subtypes(self):
-        """Get the field names of this type that originate from subtypes only.
-
-        Returns
-        -------
-        list<str>
-            List of field names from subtypes.
-
-        """
         return ['diepte_laag_van', 'diepte_laag_tot', 'lid1', 'relatie_lid1_lid2', 'lid2']
 
     def get_field_names_nosubtypes(self):
-        """Get the field names for this type, without including fields from
-        subtypes.
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'pkey_sondering', 'betrouwbaarheid_interpretatie', 'x', 'y']
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'pkey_sondering')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'

--- a/tests/test_types_itp_formelestratigrafie.py
+++ b/tests/test_types_itp_formelestratigrafie.py
@@ -13,32 +13,25 @@ from tests.test_search_itp_formelestratigrafie import (location_dov_xml,
 class TestFormeleStratigrafie(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.FormeleStratigrafie class."""
-    def get_type(self):
-        return FormeleStratigrafie
 
-    def get_namespace(self):
-        return 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    datatype_class = FormeleStratigrafie
+    namespace = 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    pkey_base = build_dov_url('data/interpretatie/')
 
-    def get_pkey_base(self):
-        return build_dov_url('data/interpretatie/')
+    field_names = [
+        'pkey_interpretatie', 'pkey_boring',
+        'pkey_sondering', 'betrouwbaarheid_interpretatie', 'x', 'y',
+        'diepte_laag_van', 'diepte_laag_tot', 'lid1', 'relatie_lid1_lid2',
+        'lid2']
+    field_names_subtypes = [
+        'diepte_laag_van', 'diepte_laag_tot', 'lid1', 'relatie_lid1_lid2',
+        'lid2']
+    field_names_nosubtypes = [
+        'pkey_interpretatie', 'pkey_boring',
+        'pkey_sondering', 'betrouwbaarheid_interpretatie', 'x', 'y']
 
-    def get_field_names(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'pkey_sondering', 'betrouwbaarheid_interpretatie', 'x', 'y',
-                'diepte_laag_van', 'diepte_laag_tot', 'lid1', 'relatie_lid1_lid2', 'lid2']
+    valid_returnfields = ('pkey_interpretatie', 'pkey_sondering')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
-    def get_field_names_subtypes(self):
-        return ['diepte_laag_van', 'diepte_laag_tot', 'lid1', 'relatie_lid1_lid2', 'lid2']
-
-    def get_field_names_nosubtypes(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'pkey_sondering', 'betrouwbaarheid_interpretatie', 'x', 'y']
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'pkey_sondering')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'

--- a/tests/test_types_itp_gecodeerdelithologie.py
+++ b/tests/test_types_itp_gecodeerdelithologie.py
@@ -3,64 +3,24 @@ pydov.types.interpretaties.InformeleStratigrafie class."""
 from pydov.types.interpretaties import GecodeerdeLithologie
 from pydov.util.dovutil import build_dov_url
 from tests.abstract import AbstractTestTypes
-
 from tests.test_search_itp_gecodeerdelithologie import (
-    wfs_feature,
-    wfs_getfeature,
-    mp_dov_xml,
-    location_wfs_feature,
-    location_wfs_getfeature,
-    location_dov_xml,
-)
+    location_dov_xml, location_wfs_feature, location_wfs_getfeature,
+    mp_dov_xml, wfs_feature, wfs_getfeature)
 
 
 class TestGecodeerdeLithologie(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.GecodeerdeLithologie class."""
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretatie.GecodeerdeLithologie
-            Class reference for the GecodeerdeLithologie class.
-
-        """
         return GecodeerdeLithologie
 
     def get_namespace(self):
-        """Get the WFS namespace associated with this datatype.
-
-        Returns
-        -------
-        str
-            WFS namespace for this type.
-
-        """
         return 'http://dov.vlaanderen.be/ocdov/interpretaties'
 
     def get_pkey_base(self):
-        """Get the base URL for the permanent keys of this datatype.
-
-        Returns
-        -------
-        str
-            Base URL for the permanent keys of this datatype. For example
-            "https://www.dov.vlaanderen.be/data/boring/"
-
-        """
         return build_dov_url('data/interpretatie/')
 
     def get_field_names(self):
-        """Get the field names for this type as listed in the documentation in
-        docs/description_output_dataframes.rst
-
-        Returns
-        -------
-        list
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y',
                 'diepte_laag_van', 'diepte_laag_tot',
@@ -70,14 +30,6 @@ class TestGecodeerdeLithologie(AbstractTestTypes):
                 'bijmenging3_plaatselijk', 'bijmenging3_hoeveelheid', 'bijmenging3_grondsoort',]
 
     def get_field_names_subtypes(self):
-        """Get the field names of this type that originate from subtypes only.
-
-        Returns
-        -------
-        list<str>
-            List of field names from subtypes.
-
-        """
         return ['diepte_laag_van', 'diepte_laag_tot',
                 'hoofdnaam1_grondsoort', 'hoofdnaam2_grondsoort',
                 'bijmenging1_plaatselijk', 'bijmenging1_hoeveelheid', 'bijmenging1_grondsoort',
@@ -85,48 +37,14 @@ class TestGecodeerdeLithologie(AbstractTestTypes):
                 'bijmenging3_plaatselijk', 'bijmenging3_hoeveelheid', 'bijmenging3_grondsoort',]
 
     def get_field_names_nosubtypes(self):
-        """Get the field names for this type, without including fields from
-        subtypes.
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y']
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'pkey_boring')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'

--- a/tests/test_types_itp_gecodeerdelithologie.py
+++ b/tests/test_types_itp_gecodeerdelithologie.py
@@ -11,40 +11,37 @@ from tests.test_search_itp_gecodeerdelithologie import (
 class TestGecodeerdeLithologie(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.GecodeerdeLithologie class."""
-    def get_type(self):
-        return GecodeerdeLithologie
 
-    def get_namespace(self):
-        return 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    datatype_class = GecodeerdeLithologie
+    namespace = 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    pkey_base = build_dov_url('data/interpretatie/')
 
-    def get_pkey_base(self):
-        return build_dov_url('data/interpretatie/')
+    field_names = [
+        'pkey_interpretatie', 'pkey_boring',
+        'betrouwbaarheid_interpretatie', 'x', 'y',
+        'diepte_laag_van', 'diepte_laag_tot',
+        'hoofdnaam1_grondsoort', 'hoofdnaam2_grondsoort',
+        'bijmenging1_plaatselijk', 'bijmenging1_hoeveelheid',
+        'bijmenging1_grondsoort',
+        'bijmenging2_plaatselijk', 'bijmenging2_hoeveelheid',
+        'bijmenging2_grondsoort',
+        'bijmenging3_plaatselijk', 'bijmenging3_hoeveelheid',
+        'bijmenging3_grondsoort']
+    field_names_subtypes = [
+        'diepte_laag_van', 'diepte_laag_tot',
+        'hoofdnaam1_grondsoort', 'hoofdnaam2_grondsoort',
+        'bijmenging1_plaatselijk', 'bijmenging1_hoeveelheid',
+        'bijmenging1_grondsoort',
+        'bijmenging2_plaatselijk', 'bijmenging2_hoeveelheid',
+        'bijmenging2_grondsoort',
+        'bijmenging3_plaatselijk', 'bijmenging3_hoeveelheid',
+        'bijmenging3_grondsoort']
+    field_names_nosubtypes = [
+        'pkey_interpretatie', 'pkey_boring',
+        'betrouwbaarheid_interpretatie', 'x', 'y']
 
-    def get_field_names(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y',
-                'diepte_laag_van', 'diepte_laag_tot',
-                'hoofdnaam1_grondsoort', 'hoofdnaam2_grondsoort',
-                'bijmenging1_plaatselijk', 'bijmenging1_hoeveelheid', 'bijmenging1_grondsoort',
-                'bijmenging2_plaatselijk', 'bijmenging2_hoeveelheid', 'bijmenging2_grondsoort',
-                'bijmenging3_plaatselijk', 'bijmenging3_hoeveelheid', 'bijmenging3_grondsoort',]
+    valid_returnfields = ('pkey_interpretatie', 'pkey_boring')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
-    def get_field_names_subtypes(self):
-        return ['diepte_laag_van', 'diepte_laag_tot',
-                'hoofdnaam1_grondsoort', 'hoofdnaam2_grondsoort',
-                'bijmenging1_plaatselijk', 'bijmenging1_hoeveelheid', 'bijmenging1_grondsoort',
-                'bijmenging2_plaatselijk', 'bijmenging2_hoeveelheid', 'bijmenging2_grondsoort',
-                'bijmenging3_plaatselijk', 'bijmenging3_hoeveelheid', 'bijmenging3_grondsoort',]
-
-    def get_field_names_nosubtypes(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y']
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'pkey_boring')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'

--- a/tests/test_types_itp_geotechnischecodering.py
+++ b/tests/test_types_itp_geotechnischecodering.py
@@ -3,64 +3,24 @@ pydov.types.interpretaties.GeotechnischeCodering class."""
 from pydov.types.interpretaties import GeotechnischeCodering
 from pydov.util.dovutil import build_dov_url
 from tests.abstract import AbstractTestTypes
-
 from tests.test_search_itp_geotechnischecodering import (
-    wfs_feature,
-    wfs_getfeature,
-    mp_dov_xml,
-    location_wfs_feature,
-    location_wfs_getfeature,
-    location_dov_xml,
-)
+    location_dov_xml, location_wfs_feature, location_wfs_getfeature,
+    mp_dov_xml, wfs_feature, wfs_getfeature)
 
 
 class TestGeotechnischeCodering(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.GeotechnischeCodering class."""
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretatie.GeotechnischeCodering
-            Class reference for the GeotechnischeCodering class.
-
-        """
         return GeotechnischeCodering
 
     def get_namespace(self):
-        """Get the WFS namespace associated with this datatype.
-
-        Returns
-        -------
-        str
-            WFS namespace for this type.
-
-        """
         return 'http://dov.vlaanderen.be/ocdov/interpretaties'
 
     def get_pkey_base(self):
-        """Get the base URL for the permanent keys of this datatype.
-
-        Returns
-        -------
-        str
-            Base URL for the permanent keys of this datatype. For example
-            "https://www.dov.vlaanderen.be/data/boring/"
-
-        """
         return build_dov_url('data/interpretatie/')
 
     def get_field_names(self):
-        """Get the field names for this type as listed in the documentation in
-        docs/description_output_dataframes.rst
-
-        Returns
-        -------
-        list
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y',
                 'diepte_laag_van', 'diepte_laag_tot',
@@ -73,14 +33,6 @@ class TestGeotechnischeCodering(AbstractTestTypes):
                 'bijmenging3_grondsoort',]
 
     def get_field_names_subtypes(self):
-        """Get the field names of this type that originate from subtypes only.
-
-        Returns
-        -------
-        list<str>
-            List of field names from subtypes.
-
-        """
         return ['diepte_laag_van', 'diepte_laag_tot',
                 'hoofdnaam1_grondsoort', 'hoofdnaam2_grondsoort',
                 'bijmenging1_plaatselijk', 'bijmenging1_hoeveelheid',
@@ -91,48 +43,14 @@ class TestGeotechnischeCodering(AbstractTestTypes):
                 'bijmenging3_grondsoort',]
 
     def get_field_names_nosubtypes(self):
-        """Get the field names for this type, without including fields from
-        subtypes.
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y']
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'pkey_boring')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'

--- a/tests/test_types_itp_geotechnischecodering.py
+++ b/tests/test_types_itp_geotechnischecodering.py
@@ -11,46 +11,37 @@ from tests.test_search_itp_geotechnischecodering import (
 class TestGeotechnischeCodering(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.GeotechnischeCodering class."""
-    def get_type(self):
-        return GeotechnischeCodering
 
-    def get_namespace(self):
-        return 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    datatype_class = GeotechnischeCodering
+    namespace = 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    pkey_base = build_dov_url('data/interpretatie/')
 
-    def get_pkey_base(self):
-        return build_dov_url('data/interpretatie/')
+    field_names = [
+        'pkey_interpretatie', 'pkey_boring',
+        'betrouwbaarheid_interpretatie', 'x', 'y',
+        'diepte_laag_van', 'diepte_laag_tot',
+        'hoofdnaam1_grondsoort', 'hoofdnaam2_grondsoort',
+        'bijmenging1_plaatselijk', 'bijmenging1_hoeveelheid',
+        'bijmenging1_grondsoort',
+        'bijmenging2_plaatselijk', 'bijmenging2_hoeveelheid',
+        'bijmenging2_grondsoort',
+        'bijmenging3_plaatselijk', 'bijmenging3_hoeveelheid',
+        'bijmenging3_grondsoort']
+    field_names_subtypes = [
+        'diepte_laag_van', 'diepte_laag_tot',
+        'hoofdnaam1_grondsoort', 'hoofdnaam2_grondsoort',
+        'bijmenging1_plaatselijk', 'bijmenging1_hoeveelheid',
+        'bijmenging1_grondsoort',
+        'bijmenging2_plaatselijk', 'bijmenging2_hoeveelheid',
+        'bijmenging2_grondsoort',
+        'bijmenging3_plaatselijk', 'bijmenging3_hoeveelheid',
+        'bijmenging3_grondsoort']
+    field_names_nosubtypes = [
+        'pkey_interpretatie', 'pkey_boring',
+        'betrouwbaarheid_interpretatie', 'x', 'y']
 
-    def get_field_names(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y',
-                'diepte_laag_van', 'diepte_laag_tot',
-                'hoofdnaam1_grondsoort', 'hoofdnaam2_grondsoort',
-                'bijmenging1_plaatselijk', 'bijmenging1_hoeveelheid',
-                'bijmenging1_grondsoort',
-                'bijmenging2_plaatselijk', 'bijmenging2_hoeveelheid',
-                'bijmenging2_grondsoort',
-                'bijmenging3_plaatselijk', 'bijmenging3_hoeveelheid',
-                'bijmenging3_grondsoort',]
+    valid_returnfields = ('pkey_interpretatie', 'pkey_boring')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
-    def get_field_names_subtypes(self):
-        return ['diepte_laag_van', 'diepte_laag_tot',
-                'hoofdnaam1_grondsoort', 'hoofdnaam2_grondsoort',
-                'bijmenging1_plaatselijk', 'bijmenging1_hoeveelheid',
-                'bijmenging1_grondsoort',
-                'bijmenging2_plaatselijk', 'bijmenging2_hoeveelheid',
-                'bijmenging2_grondsoort',
-                'bijmenging3_plaatselijk', 'bijmenging3_hoeveelheid',
-                'bijmenging3_grondsoort',]
-
-    def get_field_names_nosubtypes(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y']
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'pkey_boring')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'

--- a/tests/test_types_itp_hydrogeologischestratigrafie.py
+++ b/tests/test_types_itp_hydrogeologischestratigrafie.py
@@ -11,32 +11,23 @@ from tests.test_search_itp_hydrogeologischestratigrafie import (
 class TestHydrogeologischeStratigrafie(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.HydrogeologischeStratigrafie class."""
-    def get_type(self):
-        return HydrogeologischeStratigrafie
 
-    def get_namespace(self):
-        return 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    datatype_class = HydrogeologischeStratigrafie
+    namespace = 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    pkey_base = build_dov_url('data/interpretatie/')
 
-    def get_pkey_base(self):
-        return build_dov_url('data/interpretatie/')
+    field_names = [
+        'pkey_interpretatie', 'pkey_boring',
+        'betrouwbaarheid_interpretatie', 'x', 'y', 'diepte_laag_van',
+        'diepte_laag_tot', 'aquifer']
+    field_names_subtypes = [
+        'diepte_laag_van', 'diepte_laag_tot', 'aquifer']
+    field_names_nosubtypes = [
+        'pkey_interpretatie', 'pkey_boring',
+        'betrouwbaarheid_interpretatie', 'x', 'y']
 
-    def get_field_names(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y', 'diepte_laag_van',
-                'diepte_laag_tot', 'aquifer']
+    valid_returnfields = ('pkey_interpretatie', 'pkey_boring')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
-    def get_field_names_subtypes(self):
-        return ['diepte_laag_van', 'diepte_laag_tot', 'aquifer']
-
-    def get_field_names_nosubtypes(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y']
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'pkey_boring')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'

--- a/tests/test_types_itp_hydrogeologischestratigrafie.py
+++ b/tests/test_types_itp_hydrogeologischestratigrafie.py
@@ -3,122 +3,40 @@ pydov.types.interpretaties.InformeleStratigrafie class."""
 from pydov.types.interpretaties import HydrogeologischeStratigrafie
 from pydov.util.dovutil import build_dov_url
 from tests.abstract import AbstractTestTypes
-
 from tests.test_search_itp_hydrogeologischestratigrafie import (
-    wfs_feature,
-    wfs_getfeature,
-    mp_dov_xml,
-    location_wfs_feature,
-    location_wfs_getfeature,
-    location_dov_xml,
-)
+    location_dov_xml, location_wfs_feature, location_wfs_getfeature,
+    mp_dov_xml, wfs_feature, wfs_getfeature)
 
 
 class TestHydrogeologischeStratigrafie(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.HydrogeologischeStratigrafie class."""
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretatie.HydrogeologischeStratigrafie
-            Class reference for the HydrogeologischeStratigrafie class.
-
-        """
         return HydrogeologischeStratigrafie
 
     def get_namespace(self):
-        """Get the WFS namespace associated with this datatype.
-
-        Returns
-        -------
-        str
-            WFS namespace for this type.
-
-        """
         return 'http://dov.vlaanderen.be/ocdov/interpretaties'
 
     def get_pkey_base(self):
-        """Get the base URL for the permanent keys of this datatype.
-
-        Returns
-        -------
-        str
-            Base URL for the permanent keys of this datatype. For example
-            "https://www.dov.vlaanderen.be/data/boring/"
-
-        """
         return build_dov_url('data/interpretatie/')
 
     def get_field_names(self):
-        """Get the field names for this type as listed in the documentation in
-        docs/description_output_dataframes.rst
-
-        Returns
-        -------
-        list
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y', 'diepte_laag_van',
                 'diepte_laag_tot', 'aquifer']
 
     def get_field_names_subtypes(self):
-        """Get the field names of this type that originate from subtypes only.
-
-        Returns
-        -------
-        list<str>
-            List of field names from subtypes.
-
-        """
         return ['diepte_laag_van', 'diepte_laag_tot', 'aquifer']
 
     def get_field_names_nosubtypes(self):
-        """Get the field names for this type, without including fields from
-        subtypes.
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y']
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'pkey_boring')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'

--- a/tests/test_types_itp_informelehydrogeologischestratigrafie.py
+++ b/tests/test_types_itp_informelehydrogeologischestratigrafie.py
@@ -14,32 +14,23 @@ from tests.test_search_itp_formelestratigrafie import (location_dov_xml,
 class TestInformeleHydrogeologischeFormeleStratigrafie(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.FormeleStratigrafie class."""
-    def get_type(self):
-        return InformeleHydrogeologischeStratigrafie
 
-    def get_namespace(self):
-        return 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    datatype_class = InformeleHydrogeologischeStratigrafie
+    namespace = 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    pkey_base = build_dov_url('data/interpretatie/')
 
-    def get_pkey_base(self):
-        return build_dov_url('data/interpretatie/')
+    field_names = [
+        'pkey_interpretatie', 'pkey_boring',
+        'betrouwbaarheid_interpretatie', 'x', 'y',
+        'diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
+    field_names_subtypes = [
+        'diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
+    field_names_nosubtypes = [
+        'pkey_interpretatie', 'pkey_boring',
+        'betrouwbaarheid_interpretatie', 'x', 'y']
 
-    def get_field_names(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y',
-                'diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
+    valid_returnfields = ('pkey_interpretatie', 'pkey_boring')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
-    def get_field_names_subtypes(self):
-        return ['diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
-
-    def get_field_names_nosubtypes(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y']
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'pkey_boring')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'

--- a/tests/test_types_itp_informelehydrogeologischestratigrafie.py
+++ b/tests/test_types_itp_informelehydrogeologischestratigrafie.py
@@ -1,127 +1,45 @@
 """Module grouping tests for the
 pydov.types.interpretaties.FormeleStratigrafie class."""
-from pydov.types.interpretaties import (
-    FormeleStratigrafie,
-    InformeleHydrogeologischeStratigrafie,
-)
+from pydov.types.interpretaties import (FormeleStratigrafie,
+                                        InformeleHydrogeologischeStratigrafie)
 from pydov.util.dovutil import build_dov_url
 from tests.abstract import AbstractTestTypes
-
-from tests.test_search_itp_formelestratigrafie import (
-    wfs_feature,
-    wfs_getfeature,
-    mp_dov_xml,
-    location_wfs_feature,
-    location_wfs_getfeature,
-    location_dov_xml,
-)
+from tests.test_search_itp_formelestratigrafie import (location_dov_xml,
+                                                       location_wfs_feature,
+                                                       location_wfs_getfeature,
+                                                       mp_dov_xml, wfs_feature,
+                                                       wfs_getfeature)
 
 
 class TestInformeleHydrogeologischeFormeleStratigrafie(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.FormeleStratigrafie class."""
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretaties.InformeleHydrogeologischeStratigrafie
-            Class reference for the InformeleHydrogeologischeStratigrafie class.
-
-        """
         return InformeleHydrogeologischeStratigrafie
 
     def get_namespace(self):
-        """Get the WFS namespace associated with this datatype.
-
-        Returns
-        -------
-        str
-            WFS namespace for this type.
-
-        """
         return 'http://dov.vlaanderen.be/ocdov/interpretaties'
 
     def get_pkey_base(self):
-        """Get the base URL for the permanent keys of this datatype.
-
-        Returns
-        -------
-        str
-            Base URL for the permanent keys of this datatype. For example
-            "https://www.dov.vlaanderen.be/data/interpretatie/"
-
-        """
         return build_dov_url('data/interpretatie/')
 
     def get_field_names(self):
-        """Get the field names for this type as listed in the documentation in
-        docs/description_output_dataframes.rst
-
-        Returns
-        -------
-        list
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y',
                 'diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
 
     def get_field_names_subtypes(self):
-        """Get the field names of this type that originate from subtypes only.
-
-        Returns
-        -------
-        list<str>
-            List of field names from subtypes.
-
-        """
         return ['diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
 
     def get_field_names_nosubtypes(self):
-        """Get the field names for this type, without including fields from
-        subtypes.
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y']
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'pkey_boring')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'

--- a/tests/test_types_itp_informelestratigrafie.py
+++ b/tests/test_types_itp_informelestratigrafie.py
@@ -11,32 +11,23 @@ from tests.test_search_itp_informelestratigrafie import (
 class TestInformeleStratigrafie(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.InformeleStratigrafie class."""
-    def get_type(self):
-        return InformeleStratigrafie
 
-    def get_namespace(self):
-        return 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    datatype_class = InformeleStratigrafie
+    namespace = 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    pkey_base = build_dov_url('data/interpretatie/')
 
-    def get_pkey_base(self):
-        return build_dov_url('data/interpretatie/')
+    field_names = [
+        'pkey_interpretatie', 'pkey_boring',
+        'pkey_sondering', 'betrouwbaarheid_interpretatie', 'x', 'y',
+        'diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
+    field_names_subtypes = [
+        'diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
+    field_names_nosubtypes = [
+        'pkey_interpretatie', 'pkey_boring',
+        'pkey_sondering', 'betrouwbaarheid_interpretatie', 'x', 'y']
 
-    def get_field_names(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'pkey_sondering', 'betrouwbaarheid_interpretatie', 'x', 'y',
-                'diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
+    valid_returnfields = ('pkey_interpretatie', 'pkey_boring')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
-    def get_field_names_subtypes(self):
-        return ['diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
-
-    def get_field_names_nosubtypes(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'pkey_sondering', 'betrouwbaarheid_interpretatie', 'x', 'y']
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'pkey_boring')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'

--- a/tests/test_types_itp_informelestratigrafie.py
+++ b/tests/test_types_itp_informelestratigrafie.py
@@ -3,122 +3,40 @@ pydov.types.interpretaties.InformeleStratigrafie class."""
 from pydov.types.interpretaties import InformeleStratigrafie
 from pydov.util.dovutil import build_dov_url
 from tests.abstract import AbstractTestTypes
-
 from tests.test_search_itp_informelestratigrafie import (
-    wfs_feature,
-    wfs_getfeature,
-    mp_dov_xml,
-    location_wfs_feature,
-    location_wfs_getfeature,
-    location_dov_xml,
-)
+    location_dov_xml, location_wfs_feature, location_wfs_getfeature,
+    mp_dov_xml, wfs_feature, wfs_getfeature)
 
 
 class TestInformeleStratigrafie(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.InformeleStratigrafie class."""
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.grondwaterfilter.GrondwaterFilter
-            Class reference for the GrondwaterFilter class.
-
-        """
         return InformeleStratigrafie
 
     def get_namespace(self):
-        """Get the WFS namespace associated with this datatype.
-
-        Returns
-        -------
-        str
-            WFS namespace for this type.
-
-        """
         return 'http://dov.vlaanderen.be/ocdov/interpretaties'
 
     def get_pkey_base(self):
-        """Get the base URL for the permanent keys of this datatype.
-
-        Returns
-        -------
-        str
-            Base URL for the permanent keys of this datatype. For example
-            "https://www.dov.vlaanderen.be/data/boring/"
-
-        """
         return build_dov_url('data/interpretatie/')
 
     def get_field_names(self):
-        """Get the field names for this type as listed in the documentation in
-        docs/description_output_dataframes.rst
-
-        Returns
-        -------
-        list
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'pkey_sondering', 'betrouwbaarheid_interpretatie', 'x', 'y',
                 'diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
 
     def get_field_names_subtypes(self):
-        """Get the field names of this type that originate from subtypes only.
-
-        Returns
-        -------
-        list<str>
-            List of field names from subtypes.
-
-        """
         return ['diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
 
     def get_field_names_nosubtypes(self):
-        """Get the field names for this type, without including fields from
-        subtypes.
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'pkey_sondering', 'betrouwbaarheid_interpretatie', 'x', 'y']
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'pkey_boring')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'

--- a/tests/test_types_itp_lithologischebeschrijvingen.py
+++ b/tests/test_types_itp_lithologischebeschrijvingen.py
@@ -11,32 +11,23 @@ from tests.test_search_itp_lithologischebeschrijvingen import (
 class TestLithologischeBeschrijvingen(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.LithologischeBeschrijvingen class."""
-    def get_type(self):
-        return LithologischeBeschrijvingen
 
-    def get_namespace(self):
-        return 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    datatype_class = LithologischeBeschrijvingen
+    namespace = 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    pkey_base = build_dov_url('data/interpretatie/')
 
-    def get_pkey_base(self):
-        return build_dov_url('data/interpretatie/')
+    field_names = [
+        'pkey_interpretatie', 'pkey_boring',
+        'betrouwbaarheid_interpretatie', 'x', 'y',
+        'diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
+    field_names_subtypes = [
+        'diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
+    field_names_nosubtypes = [
+        'pkey_interpretatie', 'pkey_boring',
+        'betrouwbaarheid_interpretatie', 'x', 'y']
 
-    def get_field_names(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y',
-                'diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
+    valid_returnfields = ('pkey_interpretatie', 'pkey_boring')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
-    def get_field_names_subtypes(self):
-        return ['diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
-
-    def get_field_names_nosubtypes(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y']
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'pkey_boring')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'

--- a/tests/test_types_itp_lithologischebeschrijvingen.py
+++ b/tests/test_types_itp_lithologischebeschrijvingen.py
@@ -3,122 +3,40 @@ pydov.types.interpretaties.LithologischeBeschrijvingen class."""
 from pydov.types.interpretaties import LithologischeBeschrijvingen
 from pydov.util.dovutil import build_dov_url
 from tests.abstract import AbstractTestTypes
-
 from tests.test_search_itp_lithologischebeschrijvingen import (
-    wfs_feature,
-    wfs_getfeature,
-    mp_dov_xml,
-    location_wfs_feature,
-    location_wfs_getfeature,
-    location_dov_xml,
-)
+    location_dov_xml, location_wfs_feature, location_wfs_getfeature,
+    mp_dov_xml, wfs_feature, wfs_getfeature)
 
 
 class TestLithologischeBeschrijvingen(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.LithologischeBeschrijvingen class."""
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretatie.LithologischeBeschrijvingen
-            Class reference for the LithologischeBeschrijvingen class.
-
-        """
         return LithologischeBeschrijvingen
 
     def get_namespace(self):
-        """Get the WFS namespace associated with this datatype.
-
-        Returns
-        -------
-        str
-            WFS namespace for this type.
-
-        """
         return 'http://dov.vlaanderen.be/ocdov/interpretaties'
 
     def get_pkey_base(self):
-        """Get the base URL for the permanent keys of this datatype.
-
-        Returns
-        -------
-        str
-            Base URL for the permanent keys of this datatype. For example
-            "https://www.dov.vlaanderen.be/data/boring/"
-
-        """
         return build_dov_url('data/interpretatie/')
 
     def get_field_names(self):
-        """Get the field names for this type as listed in the documentation in
-        docs/description_output_dataframes.rst
-
-        Returns
-        -------
-        list
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y',
                 'diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
 
     def get_field_names_subtypes(self):
-        """Get the field names of this type that originate from subtypes only.
-
-        Returns
-        -------
-        list<str>
-            List of field names from subtypes.
-
-        """
         return ['diepte_laag_van', 'diepte_laag_tot', 'beschrijving']
 
     def get_field_names_nosubtypes(self):
-        """Get the field names for this type, without including fields from
-        subtypes.
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y']
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'pkey_boring')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'

--- a/tests/test_types_itp_quartairstratigrafie.py
+++ b/tests/test_types_itp_quartairstratigrafie.py
@@ -11,34 +11,25 @@ from tests.test_search_itp_quartairstratigrafie import (
 class TestQuartairStratigrafie(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.QuartairStratigrafie class."""
-    def get_type(self):
-        return QuartairStratigrafie
 
-    def get_namespace(self):
-        return 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    datatype_class = QuartairStratigrafie
+    namespace = 'http://dov.vlaanderen.be/ocdov/interpretaties'
+    pkey_base = build_dov_url('data/interpretatie/')
 
-    def get_pkey_base(self):
-        return build_dov_url('data/interpretatie/')
+    field_names = [
+        'pkey_interpretatie', 'pkey_boring',
+        'betrouwbaarheid_interpretatie', 'x', 'y',
+        'diepte_laag_van', 'diepte_laag_tot', 'lid1',
+        'relatie_lid1_lid2', 'lid2']
+    field_names_subtypes = [
+        'diepte_laag_van', 'diepte_laag_tot', 'lid1',
+        'relatie_lid1_lid2', 'lid2']
+    field_names_nosubtypes = [
+        'pkey_interpretatie', 'pkey_boring',
+        'betrouwbaarheid_interpretatie', 'x', 'y']
 
-    def get_field_names(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y',
-                'diepte_laag_van', 'diepte_laag_tot', 'lid1',
-                'relatie_lid1_lid2', 'lid2']
+    valid_returnfields = ('pkey_interpretatie', 'pkey_boring')
+    valid_returnfields_subtype = (
+        'pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
-    def get_field_names_subtypes(self):
-        return ['diepte_laag_van', 'diepte_laag_tot', 'lid1',
-                'relatie_lid1_lid2', 'lid2']
-
-    def get_field_names_nosubtypes(self):
-        return ['pkey_interpretatie', 'pkey_boring',
-                'betrouwbaarheid_interpretatie', 'x', 'y']
-
-    def get_valid_returnfields(self):
-        return ('pkey_interpretatie', 'pkey_boring')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
-
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'

--- a/tests/test_types_itp_quartairstratigrafie.py
+++ b/tests/test_types_itp_quartairstratigrafie.py
@@ -3,124 +3,42 @@ pydov.types.interpretaties.QuartairStratigrafie class."""
 from pydov.types.interpretaties import QuartairStratigrafie
 from pydov.util.dovutil import build_dov_url
 from tests.abstract import AbstractTestTypes
-
 from tests.test_search_itp_quartairstratigrafie import (
-    wfs_feature,
-    wfs_getfeature,
-    mp_dov_xml,
-    location_wfs_feature,
-    location_wfs_getfeature,
-    location_dov_xml,
-)
+    location_dov_xml, location_wfs_feature, location_wfs_getfeature,
+    mp_dov_xml, wfs_feature, wfs_getfeature)
 
 
 class TestQuartairStratigrafie(AbstractTestTypes):
     """Class grouping tests for the
     pydov.types.interpretaties.QuartairStratigrafie class."""
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.interpretaties.QuartairStratigrafie
-            Class reference for the QuartairStratigrafie class.
-
-        """
         return QuartairStratigrafie
 
     def get_namespace(self):
-        """Get the WFS namespace associated with this datatype.
-
-        Returns
-        -------
-        str
-            WFS namespace for this type.
-
-        """
         return 'http://dov.vlaanderen.be/ocdov/interpretaties'
 
     def get_pkey_base(self):
-        """Get the base URL for the permanent keys of this datatype.
-
-        Returns
-        -------
-        str
-            Base URL for the permanent keys of this datatype. For example
-            "https://www.dov.vlaanderen.be/data/interpretatie/"
-
-        """
         return build_dov_url('data/interpretatie/')
 
     def get_field_names(self):
-        """Get the field names for this type as listed in the documentation in
-        docs/description_output_dataframes.rst
-
-        Returns
-        -------
-        list
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y',
                 'diepte_laag_van', 'diepte_laag_tot', 'lid1',
                 'relatie_lid1_lid2', 'lid2']
 
     def get_field_names_subtypes(self):
-        """Get the field names of this type that originate from subtypes only.
-
-        Returns
-        -------
-        list<str>
-            List of field names from subtypes.
-
-        """
         return ['diepte_laag_van', 'diepte_laag_tot', 'lid1',
                 'relatie_lid1_lid2', 'lid2']
 
     def get_field_names_nosubtypes(self):
-        """Get the field names for this type, without including fields from
-        subtypes.
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
         return ['pkey_interpretatie', 'pkey_boring',
                 'betrouwbaarheid_interpretatie', 'x', 'y']
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_interpretatie', 'pkey_boring')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_interpretatie', 'diepte_laag_van', 'diepte_laag_tot')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'

--- a/tests/test_types_sondering.py
+++ b/tests/test_types_sondering.py
@@ -3,62 +3,24 @@
 from pydov.types.sondering import Sondering
 from pydov.util.dovutil import build_dov_url
 from tests.abstract import AbstractTestTypes
+from tests.test_search_sondering import (location_dov_xml,
+                                         location_wfs_feature,
+                                         location_wfs_getfeature, mp_dov_xml,
+                                         wfs_feature, wfs_getfeature)
 
-from tests.test_search_sondering import (
-    wfs_getfeature,
-    wfs_feature,
-    mp_dov_xml,
-    location_wfs_getfeature,
-    location_wfs_feature,
-    location_dov_xml,
-)
 
 class TestSondering(AbstractTestTypes):
     """Class grouping tests for the pydov.types.sondering.Sondering class."""
     def get_type(self):
-        """Get the class reference for this datatype.
-
-        Returns
-        -------
-        pydov.types.sondering.Sondering
-            Class reference for the Sondering class.
-
-        """
         return Sondering
 
     def get_namespace(self):
-        """Get the WFS namespace associated with this datatype.
-
-        Returns
-        -------
-        str
-            WFS namespace for this type.
-
-        """
         return 'http://dov.vlaanderen.be/ocdov/dov-pub'
 
     def get_pkey_base(self):
-        """Get the base URL for the permanent keys of this datatype.
-
-        Returns
-        -------
-        str
-            Base URL for the permanent keys of this datatype. For example
-            "https://www.dov.vlaanderen.be/data/sondering/"
-
-        """
         return build_dov_url('data/sondering/')
 
     def get_field_names(self):
-        """Get the field names for this type as listed in the documentation in
-        docs/description_output_dataframes.rst
-
-        Returns
-        -------
-        list
-            List of field names.
-
-        """
         return ['pkey_sondering', 'sondeernummer', 'x', 'y',
                 'start_sondering_mtaw', 'diepte_sondering_van',
                 'diepte_sondering_tot', 'datum_aanvang', 'uitvoerder',
@@ -66,26 +28,9 @@ class TestSondering(AbstractTestTypes):
                 'diepte_gw_m', 'z', 'qc', 'Qt', 'fs', 'u', 'i']
 
     def get_field_names_subtypes(self):
-        """Get the field names of this type that originate from subtypes only.
-
-        Returns
-        -------
-        list<str>
-            List of field names from subtypes.
-
-        """
         return ['z', 'qc', 'Qt', 'fs', 'u', 'i']
 
     def get_field_names_nosubtypes(self):
-        """Get the field names for this type, without including fields from
-        subtypes.
-
-        Returns
-        -------
-        list<str>
-            List of field names.
-
-        """
         return ['pkey_sondering', 'sondeernummer', 'x', 'y',
                 'start_sondering_mtaw', 'diepte_sondering_van',
                 'diepte_sondering_tot', 'datum_aanvang', 'uitvoerder',
@@ -93,36 +38,10 @@ class TestSondering(AbstractTestTypes):
                 'diepte_gw_m']
 
     def get_valid_returnfields(self):
-        """Get a list of valid return fields from the main type.
-
-        Returns
-        -------
-        tuple
-            A tuple containing only valid return fields.
-
-        """
         return ('pkey_sondering', 'sondeernummer')
 
     def get_valid_returnfields_subtype(self):
-        """Get a list of valid return fields, including fields from a subtype.
-
-        Returns
-        -------
-        tuple
-            A tuple containing valid return fields, including fields from a
-            subtype.
-
-        """
         return ('pkey_sondering', 'sondeernummer', 'z')
 
     def get_inexistent_field(self):
-        """Get the name of a field that doesn't exist.
-
-        Returns
-        -------
-        str
-            The name of an inexistent field.
-
-        """
         return 'onbestaand'
-

--- a/tests/test_types_sondering.py
+++ b/tests/test_types_sondering.py
@@ -11,37 +11,27 @@ from tests.test_search_sondering import (location_dov_xml,
 
 class TestSondering(AbstractTestTypes):
     """Class grouping tests for the pydov.types.sondering.Sondering class."""
-    def get_type(self):
-        return Sondering
 
-    def get_namespace(self):
-        return 'http://dov.vlaanderen.be/ocdov/dov-pub'
+    datatype_class = Sondering
+    namespace = 'http://dov.vlaanderen.be/ocdov/dov-pub'
+    pkey_base = build_dov_url('data/sondering/')
 
-    def get_pkey_base(self):
-        return build_dov_url('data/sondering/')
+    field_names = [
+        'pkey_sondering', 'sondeernummer', 'x', 'y',
+        'start_sondering_mtaw', 'diepte_sondering_van',
+        'diepte_sondering_tot', 'datum_aanvang', 'uitvoerder',
+        'sondeermethode', 'apparaat', 'datum_gw_meting',
+        'diepte_gw_m', 'z', 'qc', 'Qt', 'fs', 'u', 'i']
+    field_names_subtypes = [
+        'z', 'qc', 'Qt', 'fs', 'u', 'i']
+    field_names_nosubtypes = [
+        'pkey_sondering', 'sondeernummer', 'x', 'y',
+        'start_sondering_mtaw', 'diepte_sondering_van',
+        'diepte_sondering_tot', 'datum_aanvang', 'uitvoerder',
+        'sondeermethode', 'apparaat', 'datum_gw_meting',
+        'diepte_gw_m']
 
-    def get_field_names(self):
-        return ['pkey_sondering', 'sondeernummer', 'x', 'y',
-                'start_sondering_mtaw', 'diepte_sondering_van',
-                'diepte_sondering_tot', 'datum_aanvang', 'uitvoerder',
-                'sondeermethode', 'apparaat', 'datum_gw_meting',
-                'diepte_gw_m', 'z', 'qc', 'Qt', 'fs', 'u', 'i']
+    valid_returnfields = ('pkey_sondering', 'sondeernummer')
+    valid_returnfields_subtype = ('pkey_sondering', 'sondeernummer', 'z')
 
-    def get_field_names_subtypes(self):
-        return ['z', 'qc', 'Qt', 'fs', 'u', 'i']
-
-    def get_field_names_nosubtypes(self):
-        return ['pkey_sondering', 'sondeernummer', 'x', 'y',
-                'start_sondering_mtaw', 'diepte_sondering_van',
-                'diepte_sondering_tot', 'datum_aanvang', 'uitvoerder',
-                'sondeermethode', 'apparaat', 'datum_gw_meting',
-                'diepte_gw_m']
-
-    def get_valid_returnfields(self):
-        return ('pkey_sondering', 'sondeernummer')
-
-    def get_valid_returnfields_subtype(self):
-        return ('pkey_sondering', 'sondeernummer', 'z')
-
-    def get_inexistent_field(self):
-        return 'onbestaand'
+    inexistent_field = 'onbestaand'


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

This PR removes docstrings from subclasses when they are identical to the ones provided in the upper class.

It also refactors the abstract test classes to use class variables instead of getter functions.

Should fix #262 
