### PR TITLE
Switch to workspace-level WFS endpoints

### DIFF
--- a/pydov/search/abstract.py
+++ b/pydov/search/abstract.py
@@ -119,11 +119,9 @@ class AbstractSearch(AbstractCommon):
         str
             The WFS endpoint URL.
         """
-        url = build_dov_url('geoserver/')
-        # url += "/".join(self._layer.split(':'))
-        url += self._layer.split(':')[0]
-        url += '/wfs'
-        return url
+        base_url = build_dov_url('geoserver/')
+        workspace = self._layer.split(':')[0]
+        return base_url + workspace + '/wfs'
 
     def _init_wfs(self):
         """Initialise the WFS service. If the WFS service is not

--- a/pydov/search/boring.py
+++ b/pydov/search/boring.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Module containing the search classes to retrieve DOV borehole data."""
-import pandas as pd
-
 from ..types.boring import Boring
 from .abstract import AbstractSearch
 
@@ -21,16 +19,3 @@ class BoringSearch(AbstractSearch):
 
         """
         super(BoringSearch, self).__init__('dov-pub:Boringen', objecttype)
-
-    def search(self, location=None, query=None,
-               sort_by=None, return_fields=None, max_features=None):
-        fts = self._search(location=location, query=query, sort_by=sort_by,
-                           return_fields=return_fields,
-                           max_features=max_features)
-
-        boringen = self._type.from_wfs(fts, self._wfs_namespace)
-
-        df = pd.DataFrame(
-            data=self._type.to_df_array(boringen, return_fields),
-            columns=self._type.get_field_names(return_fields))
-        return df

--- a/pydov/search/boring.py
+++ b/pydov/search/boring.py
@@ -2,21 +2,12 @@
 """Module containing the search classes to retrieve DOV borehole data."""
 import pandas as pd
 
-from pydov.types.fields import _WfsInjectedField
-
 from ..types.boring import Boring
-from ..util import owsutil
 from .abstract import AbstractSearch
 
 
 class BoringSearch(AbstractSearch):
     """Search class to retrieve information about boreholes (Boring)."""
-
-    __wfs_schema = None
-    __wfs_namespace = None
-    __md_metadata = None
-    __fc_featurecatalogue = None
-    __xsd_schemas = None
 
     def __init__(self, objecttype=Boring):
         """Initialisation.
@@ -31,54 +22,13 @@ class BoringSearch(AbstractSearch):
         """
         super(BoringSearch, self).__init__('dov-pub:Boringen', objecttype)
 
-    def _init_namespace(self):
-        if BoringSearch.__wfs_namespace is None:
-            BoringSearch.__wfs_namespace = self._get_namespace()
-
-    def _init_fields(self):
-        if self._fields is None:
-            if BoringSearch.__wfs_schema is None:
-                BoringSearch.__wfs_schema = self._get_schema()
-
-            if BoringSearch.__md_metadata is None:
-                BoringSearch.__md_metadata = self._get_remote_metadata()
-
-            if BoringSearch.__fc_featurecatalogue is None:
-                csw_url = self._get_csw_base_url()
-                fc_uuid = owsutil.get_featurecatalogue_uuid(
-                    BoringSearch.__md_metadata)
-
-                BoringSearch.__fc_featurecatalogue = \
-                    owsutil.get_remote_featurecatalogue(csw_url, fc_uuid)
-
-            if BoringSearch.__xsd_schemas is None:
-                BoringSearch.__xsd_schemas = \
-                    self._get_remote_xsd_schemas()
-
-            fields = self._build_fields(
-                BoringSearch.__wfs_schema,
-                BoringSearch.__fc_featurecatalogue,
-                BoringSearch.__xsd_schemas)
-
-            for field in fields.values():
-                if field['name'] not in self._type.get_field_names(
-                        include_wfs_injected=True):
-                    self._type.fields.append(
-                        _WfsInjectedField(name=field['name'],
-                                          datatype=field['type']))
-
-            self._fields = self._build_fields(
-                BoringSearch.__wfs_schema,
-                BoringSearch.__fc_featurecatalogue,
-                BoringSearch.__xsd_schemas)
-
     def search(self, location=None, query=None,
                sort_by=None, return_fields=None, max_features=None):
         fts = self._search(location=location, query=query, sort_by=sort_by,
                            return_fields=return_fields,
                            max_features=max_features)
 
-        boringen = self._type.from_wfs(fts, self.__wfs_namespace)
+        boringen = self._type.from_wfs(fts, self._wfs_namespace)
 
         df = pd.DataFrame(
             data=self._type.to_df_array(boringen, return_fields),

--- a/pydov/search/grondmonster.py
+++ b/pydov/search/grondmonster.py
@@ -1,22 +1,12 @@
 # -*- coding: utf-8 -*-
 """Module containing the search classes to retrieve DOV borehole data."""
-import pandas as pd
-
 from pydov.search.abstract import AbstractSearch
-from pydov.types.fields import _WfsInjectedField
 from pydov.types.grondmonster import Grondmonster
-from pydov.util import owsutil
 
 
 class GrondmonsterSearch(AbstractSearch):
     """Search class to retrieve the grain size distribution of
     ground samples ('grondmonster')"""
-
-    __wfs_schema = None
-    __wfs_namespace = None
-    __md_metadata = None
-    __fc_featurecatalogue = None
-    __xsd_schemas = None
 
     def __init__(self, objecttype=Grondmonster):
         """Initialisation.
@@ -31,61 +21,3 @@ class GrondmonsterSearch(AbstractSearch):
         """
         super(GrondmonsterSearch, self).\
             __init__('boringen:grondmonsters', objecttype)
-
-    def _init_namespace(self):
-        if GrondmonsterSearch.__wfs_namespace is None:
-            GrondmonsterSearch.__wfs_namespace = self._get_namespace()
-
-    def _init_fields(self):
-        if self._fields is None:
-            if GrondmonsterSearch.__wfs_schema is None:
-                GrondmonsterSearch.__wfs_schema = self._get_schema()
-
-            if GrondmonsterSearch.__md_metadata is None:
-                GrondmonsterSearch.__md_metadata = \
-                    self._get_remote_metadata()
-
-            if GrondmonsterSearch.__fc_featurecatalogue is None:
-                csw_url = self._get_csw_base_url()
-                fc_uuid = owsutil.get_featurecatalogue_uuid(
-                    GrondmonsterSearch.__md_metadata)
-
-                GrondmonsterSearch.__fc_featurecatalogue = \
-                    owsutil.get_remote_featurecatalogue(csw_url, fc_uuid)
-
-            if GrondmonsterSearch.__xsd_schemas is None:
-                GrondmonsterSearch.__xsd_schemas = \
-                    self._get_remote_xsd_schemas()
-
-            fields = self._build_fields(
-                GrondmonsterSearch.__wfs_schema,
-                GrondmonsterSearch.__fc_featurecatalogue,
-                GrondmonsterSearch.__xsd_schemas)
-
-            for field in fields.values():
-                if field['name'] not in self._type.get_field_names(
-                        include_wfs_injected=True):
-                    self._type.fields.append(
-                        _WfsInjectedField(name=field['name'],
-                                          datatype=field['type']))
-
-            self._fields = self._build_fields(
-                GrondmonsterSearch.__wfs_schema,
-                GrondmonsterSearch.__fc_featurecatalogue,
-                GrondmonsterSearch.__xsd_schemas)
-
-    def search(self, location=None, query=None, sort_by=None,
-               return_fields=None, max_features=None):
-        self._pre_search_validation(location, query, sort_by, return_fields,
-                                    max_features)
-
-        fts = self._search(location=location, query=query, sort_by=sort_by,
-                           return_fields=return_fields,
-                           max_features=max_features)
-
-        grondmonster = self._type.from_wfs(fts, self.__wfs_namespace)
-
-        df = pd.DataFrame(
-            data=self._type.to_df_array(grondmonster, return_fields),
-            columns=self._type.get_field_names(return_fields))
-        return df

--- a/pydov/search/grondwaterfilter.py
+++ b/pydov/search/grondwaterfilter.py
@@ -4,10 +4,7 @@
 import pandas as pd
 from owslib.fes import And, Not, PropertyIsNull
 
-from pydov.types.fields import _WfsInjectedField
-
 from ..types.grondwaterfilter import GrondwaterFilter
-from ..util import owsutil
 from .abstract import AbstractSearch
 
 
@@ -15,12 +12,6 @@ class GrondwaterFilterSearch(AbstractSearch):
     """Search class to retrieve information about groundwater screens
     (GrondwaterFilter).
     """
-
-    __wfs_schema = None
-    __wfs_namespace = None
-    __md_metadata = None
-    __fc_featurecatalogue = None
-    __xsd_schemas = None
 
     def __init__(self, objecttype=GrondwaterFilter):
         """Initialisation.
@@ -35,48 +26,6 @@ class GrondwaterFilterSearch(AbstractSearch):
         """
         super(GrondwaterFilterSearch,
               self).__init__('gw_meetnetten:meetnetten', objecttype)
-
-    def _init_namespace(self):
-        if GrondwaterFilterSearch.__wfs_namespace is None:
-            GrondwaterFilterSearch.__wfs_namespace = self._get_namespace()
-
-    def _init_fields(self):
-        if self._fields is None:
-            if GrondwaterFilterSearch.__wfs_schema is None:
-                GrondwaterFilterSearch.__wfs_schema = self._get_schema()
-
-            if GrondwaterFilterSearch.__md_metadata is None:
-                GrondwaterFilterSearch.__md_metadata = \
-                    self._get_remote_metadata()
-
-            if GrondwaterFilterSearch.__fc_featurecatalogue is None:
-                csw_url = self._get_csw_base_url()
-                fc_uuid = owsutil.get_featurecatalogue_uuid(
-                    GrondwaterFilterSearch.__md_metadata)
-
-                GrondwaterFilterSearch.__fc_featurecatalogue = \
-                    owsutil.get_remote_featurecatalogue(csw_url, fc_uuid)
-
-            if GrondwaterFilterSearch.__xsd_schemas is None:
-                GrondwaterFilterSearch.__xsd_schemas = \
-                    self._get_remote_xsd_schemas()
-
-            fields = self._build_fields(
-                GrondwaterFilterSearch.__wfs_schema,
-                GrondwaterFilterSearch.__fc_featurecatalogue,
-                GrondwaterFilterSearch.__xsd_schemas)
-
-            for field in fields.values():
-                if field['name'] not in self._type.get_field_names(
-                        include_wfs_injected=True):
-                    self._type.fields.append(
-                        _WfsInjectedField(name=field['name'],
-                                          datatype=field['type']))
-
-            self._fields = self._build_fields(
-                GrondwaterFilterSearch.__wfs_schema,
-                GrondwaterFilterSearch.__fc_featurecatalogue,
-                GrondwaterFilterSearch.__xsd_schemas)
 
     def search(self, location=None, query=None, sort_by=None,
                return_fields=None, max_features=None):
@@ -157,7 +106,7 @@ class GrondwaterFilterSearch(AbstractSearch):
                            return_fields=return_fields,
                            max_features=max_features)
 
-        gw_filters = self._type.from_wfs(fts, self.__wfs_namespace)
+        gw_filters = self._type.from_wfs(fts, self._wfs_namespace)
 
         df = pd.DataFrame(
             data=self._type.to_df_array(gw_filters, return_fields),

--- a/pydov/search/grondwatermonster.py
+++ b/pydov/search/grondwatermonster.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 """Module containing the search classes to retrieve DOV groundwater samples."""
-import pandas as pd
-
-from pydov.types.fields import _WfsInjectedField
-
 from ..types.grondwatermonster import GrondwaterMonster
-from ..util import owsutil
 from .abstract import AbstractSearch
 
 
@@ -13,12 +8,6 @@ class GrondwaterMonsterSearch(AbstractSearch):
     """Search class to retrieve information about groundwater samples
     (GrondwaterMonster).
     """
-
-    __wfs_schema = None
-    __wfs_namespace = None
-    __md_metadata = None
-    __fc_featurecatalogue = None
-    __xsd_schemas = None
 
     def __init__(self, objecttype=GrondwaterMonster):
         """Initialisation.
@@ -33,59 +22,3 @@ class GrondwaterMonsterSearch(AbstractSearch):
         """
         super(GrondwaterMonsterSearch,
               self).__init__('gw_meetnetten:grondwatermonsters', objecttype)
-
-    def _init_namespace(self):
-        if GrondwaterMonsterSearch.__wfs_namespace is None:
-            GrondwaterMonsterSearch.__wfs_namespace = self._get_namespace()
-
-    def _init_fields(self):
-        if self._fields is None:
-            if GrondwaterMonsterSearch.__wfs_schema is None:
-                GrondwaterMonsterSearch.__wfs_schema = self._get_schema()
-
-            if GrondwaterMonsterSearch.__md_metadata is None:
-                GrondwaterMonsterSearch.__md_metadata = \
-                    self._get_remote_metadata()
-
-            if GrondwaterMonsterSearch.__fc_featurecatalogue is None:
-                csw_url = self._get_csw_base_url()
-                fc_uuid = owsutil.get_featurecatalogue_uuid(
-                    GrondwaterMonsterSearch.__md_metadata)
-
-                GrondwaterMonsterSearch.__fc_featurecatalogue = \
-                    owsutil.get_remote_featurecatalogue(csw_url, fc_uuid)
-
-            if GrondwaterMonsterSearch.__xsd_schemas is None:
-                GrondwaterMonsterSearch.__xsd_schemas = \
-                    self._get_remote_xsd_schemas()
-
-            fields = self._build_fields(
-                GrondwaterMonsterSearch.__wfs_schema,
-                GrondwaterMonsterSearch.__fc_featurecatalogue,
-                GrondwaterMonsterSearch.__xsd_schemas)
-
-            for field in fields.values():
-                if field['name'] not in self._type.get_field_names(
-                        include_wfs_injected=True):
-                    self._type.fields.append(
-                        _WfsInjectedField(name=field['name'],
-                                          datatype=field['type']))
-
-            self._fields = self._build_fields(
-                GrondwaterMonsterSearch.__wfs_schema,
-                GrondwaterMonsterSearch.__fc_featurecatalogue,
-                GrondwaterMonsterSearch.__xsd_schemas)
-
-    def search(self, location=None, query=None, sort_by=None,
-               return_fields=None, max_features=None):
-        fts = self._search(location=location, query=query, sort_by=sort_by,
-                           return_fields=return_fields,
-                           max_features=max_features)
-
-        gw_filters = self._type.from_wfs(fts, self.__wfs_namespace)
-
-        df = pd.DataFrame(
-            data=self._type.to_df_array(gw_filters, return_fields),
-            columns=self._type.get_field_names(return_fields))
-
-        return df

--- a/pydov/search/interpretaties.py
+++ b/pydov/search/interpretaties.py
@@ -1,7 +1,5 @@
-import pandas as pd
-
+# -*- coding: utf-8 -*-
 from pydov.search.abstract import AbstractSearch
-from pydov.types.fields import _WfsInjectedField
 from pydov.types.interpretaties import (FormeleStratigrafie,
                                         GecodeerdeLithologie,
                                         GeotechnischeCodering,
@@ -10,17 +8,10 @@ from pydov.types.interpretaties import (FormeleStratigrafie,
                                         InformeleStratigrafie,
                                         LithologischeBeschrijvingen,
                                         QuartairStratigrafie)
-from pydov.util import owsutil
 
 
 class InformeleStratigrafieSearch(AbstractSearch):
     """Search class to retrieve information about 'informele stratigrafie'."""
-
-    __wfs_schema = None
-    __wfs_namespace = None
-    __md_metadata = None
-    __fc_featurecatalogue = None
-    __xsd_schemas = None
 
     def __init__(self, objecttype=InformeleStratigrafie):
         """Initialisation.
@@ -36,73 +27,10 @@ class InformeleStratigrafieSearch(AbstractSearch):
         super(InformeleStratigrafieSearch, self).__init__(
             'interpretaties:informele_stratigrafie', objecttype)
 
-    def _init_namespace(self):
-        if InformeleStratigrafieSearch.__wfs_namespace is None:
-            InformeleStratigrafieSearch.__wfs_namespace = self._get_namespace()
-
-    def _init_fields(self):
-        if self._fields is None:
-            if InformeleStratigrafieSearch.__wfs_schema is None:
-                InformeleStratigrafieSearch.__wfs_schema = self._get_schema()
-
-            if InformeleStratigrafieSearch.__md_metadata is None:
-                InformeleStratigrafieSearch.__md_metadata = \
-                    self._get_remote_metadata()
-
-            if InformeleStratigrafieSearch.__fc_featurecatalogue is None:
-                csw_url = self._get_csw_base_url()
-                fc_uuid = owsutil.get_featurecatalogue_uuid(
-                    InformeleStratigrafieSearch.__md_metadata)
-
-                InformeleStratigrafieSearch.__fc_featurecatalogue = \
-                    owsutil.get_remote_featurecatalogue(csw_url, fc_uuid)
-
-            if InformeleStratigrafieSearch.__xsd_schemas is None:
-                InformeleStratigrafieSearch.__xsd_schemas = \
-                    self._get_remote_xsd_schemas()
-
-            fields = self._build_fields(
-                InformeleStratigrafieSearch.__wfs_schema,
-                InformeleStratigrafieSearch.__fc_featurecatalogue,
-                InformeleStratigrafieSearch.__xsd_schemas)
-
-            for field in fields.values():
-                if field['name'] not in self._type.get_field_names(
-                        include_wfs_injected=True):
-                    self._type.fields.append(
-                        _WfsInjectedField(name=field['name'],
-                                          datatype=field['type']))
-
-            self._fields = self._build_fields(
-                InformeleStratigrafieSearch.__wfs_schema,
-                InformeleStratigrafieSearch.__fc_featurecatalogue,
-                InformeleStratigrafieSearch.__xsd_schemas)
-
-    def search(self, location=None, query=None, sort_by=None,
-               return_fields=None, max_features=None):
-        fts = self._search(location=location, query=query, sort_by=sort_by,
-                           return_fields=return_fields,
-                           extra_wfs_fields=['Type_proef', 'Proeffiche'],
-                           max_features=max_features)
-
-        interpretaties = self._type.from_wfs(
-            fts, self.__wfs_namespace)
-
-        df = pd.DataFrame(
-            data=self._type.to_df_array(interpretaties, return_fields),
-            columns=self._type.get_field_names(return_fields))
-        return df
-
 
 class FormeleStratigrafieSearch(AbstractSearch):
     """Search class to retrieve the interpretation for Formele
     stratigrafie"""
-
-    __wfs_schema = None
-    __wfs_namespace = None
-    __md_metadata = None
-    __fc_featurecatalogue = None
-    __xsd_schemas = None
 
     def __init__(self, objecttype=FormeleStratigrafie):
         """Initialisation.
@@ -118,72 +46,9 @@ class FormeleStratigrafieSearch(AbstractSearch):
         super(FormeleStratigrafieSearch, self).__init__(
             'interpretaties:formele_stratigrafie', objecttype)
 
-    def _init_namespace(self):
-        if FormeleStratigrafieSearch.__wfs_namespace is None:
-            FormeleStratigrafieSearch.__wfs_namespace = self._get_namespace()
-
-    def _init_fields(self):
-        if self._fields is None:
-            if FormeleStratigrafieSearch.__wfs_schema is None:
-                FormeleStratigrafieSearch.__wfs_schema = self._get_schema()
-
-            if FormeleStratigrafieSearch.__md_metadata is None:
-                FormeleStratigrafieSearch.__md_metadata = \
-                    self._get_remote_metadata()
-
-            if FormeleStratigrafieSearch.__fc_featurecatalogue is None:
-                csw_url = self._get_csw_base_url()
-                fc_uuid = owsutil.get_featurecatalogue_uuid(
-                    FormeleStratigrafieSearch.__md_metadata)
-
-                FormeleStratigrafieSearch.__fc_featurecatalogue = \
-                    owsutil.get_remote_featurecatalogue(csw_url, fc_uuid)
-
-            if FormeleStratigrafieSearch.__xsd_schemas is None:
-                FormeleStratigrafieSearch.__xsd_schemas = \
-                    self._get_remote_xsd_schemas()
-
-            fields = self._build_fields(
-                FormeleStratigrafieSearch.__wfs_schema,
-                FormeleStratigrafieSearch.__fc_featurecatalogue,
-                FormeleStratigrafieSearch.__xsd_schemas)
-
-            for field in fields.values():
-                if field['name'] not in self._type.get_field_names(
-                        include_wfs_injected=True):
-                    self._type.fields.append(
-                        _WfsInjectedField(name=field['name'],
-                                          datatype=field['type']))
-
-            self._fields = self._build_fields(
-                FormeleStratigrafieSearch.__wfs_schema,
-                FormeleStratigrafieSearch.__fc_featurecatalogue,
-                FormeleStratigrafieSearch.__xsd_schemas)
-
-    def search(self, location=None, query=None, sort_by=None,
-               return_fields=None, max_features=None):
-        fts = self._search(location=location, query=query, sort_by=sort_by,
-                           return_fields=return_fields,
-                           extra_wfs_fields=['Type_proef', 'Proeffiche'],
-                           max_features=max_features)
-
-        interpretaties = self._type.from_wfs(
-            fts, self.__wfs_namespace)
-
-        df = pd.DataFrame(
-            data=self._type.to_df_array(interpretaties, return_fields),
-            columns=self._type.get_field_names(return_fields))
-        return df
-
 
 class HydrogeologischeStratigrafieSearch(AbstractSearch):
     """Search class to retrieve hydrogeological interpretations """
-
-    __wfs_schema = None
-    __wfs_namespace = None
-    __md_metadata = None
-    __fc_featurecatalogue = None
-    __xsd_schemas = None
 
     def __init__(self, objecttype=HydrogeologischeStratigrafie):
         """Initialisation.
@@ -200,74 +65,9 @@ class HydrogeologischeStratigrafieSearch(AbstractSearch):
             'interpretaties:hydrogeologische_stratigrafie',
             objecttype)
 
-    def _init_namespace(self):
-        if HydrogeologischeStratigrafieSearch.__wfs_namespace is None:
-            HydrogeologischeStratigrafieSearch.__wfs_namespace = \
-                self._get_namespace()
-
-    def _init_fields(self):
-        if self._fields is None:
-            if HydrogeologischeStratigrafieSearch.__wfs_schema is None:
-                HydrogeologischeStratigrafieSearch.__wfs_schema = \
-                    self._get_schema()
-
-            if HydrogeologischeStratigrafieSearch.__md_metadata is None:
-                HydrogeologischeStratigrafieSearch.__md_metadata = \
-                    self._get_remote_metadata()
-
-            if HydrogeologischeStratigrafieSearch.__fc_featurecatalogue \
-                    is None:
-                csw_url = self._get_csw_base_url()
-                fc_uuid = owsutil.get_featurecatalogue_uuid(
-                    HydrogeologischeStratigrafieSearch.__md_metadata)
-
-                HydrogeologischeStratigrafieSearch.__fc_featurecatalogue = \
-                    owsutil.get_remote_featurecatalogue(csw_url, fc_uuid)
-
-            if HydrogeologischeStratigrafieSearch.__xsd_schemas is None:
-                HydrogeologischeStratigrafieSearch.__xsd_schemas = \
-                    self._get_remote_xsd_schemas()
-
-            fields = self._build_fields(
-                HydrogeologischeStratigrafieSearch.__wfs_schema,
-                HydrogeologischeStratigrafieSearch.__fc_featurecatalogue,
-                HydrogeologischeStratigrafieSearch.__xsd_schemas)
-
-            for field in fields.values():
-                if field['name'] not in self._type.get_field_names(
-                        include_wfs_injected=True):
-                    self._type.fields.append(
-                        _WfsInjectedField(name=field['name'],
-                                          datatype=field['type']))
-
-            self._fields = self._build_fields(
-                HydrogeologischeStratigrafieSearch.__wfs_schema,
-                HydrogeologischeStratigrafieSearch.__fc_featurecatalogue,
-                HydrogeologischeStratigrafieSearch.__xsd_schemas)
-
-    def search(self, location=None, query=None, sort_by=None,
-               return_fields=None, max_features=None):
-        fts = self._search(location=location, query=query, sort_by=sort_by,
-                           return_fields=return_fields,
-                           max_features=max_features)
-
-        interpretaties = self._type.from_wfs(
-            fts, self.__wfs_namespace)
-
-        df = pd.DataFrame(
-            data=self._type.to_df_array(interpretaties, return_fields),
-            columns=self._type.get_field_names(return_fields))
-        return df
-
 
 class LithologischeBeschrijvingenSearch(AbstractSearch):
     """Search class to retrieve lithologische beschrijvingen """
-
-    __wfs_schema = None
-    __wfs_namespace = None
-    __md_metadata = None
-    __fc_featurecatalogue = None
-    __xsd_schemas = None
 
     def __init__(self, objecttype=LithologischeBeschrijvingen):
         """Initialisation.
@@ -284,74 +84,9 @@ class LithologischeBeschrijvingenSearch(AbstractSearch):
             'interpretaties:lithologische_beschrijvingen',
             objecttype)
 
-    def _init_namespace(self):
-        if LithologischeBeschrijvingenSearch.__wfs_namespace is None:
-            LithologischeBeschrijvingenSearch.__wfs_namespace = \
-                self._get_namespace()
-
-    def _init_fields(self):
-        if self._fields is None:
-            if LithologischeBeschrijvingenSearch.__wfs_schema is None:
-                LithologischeBeschrijvingenSearch.__wfs_schema = \
-                    self._get_schema()
-
-            if LithologischeBeschrijvingenSearch.__md_metadata is None:
-                LithologischeBeschrijvingenSearch.__md_metadata = \
-                    self._get_remote_metadata()
-
-            if LithologischeBeschrijvingenSearch.__fc_featurecatalogue \
-                    is None:
-                csw_url = self._get_csw_base_url()
-                fc_uuid = owsutil.get_featurecatalogue_uuid(
-                    LithologischeBeschrijvingenSearch.__md_metadata)
-
-                LithologischeBeschrijvingenSearch.__fc_featurecatalogue = \
-                    owsutil.get_remote_featurecatalogue(csw_url, fc_uuid)
-
-            if LithologischeBeschrijvingenSearch.__xsd_schemas is None:
-                LithologischeBeschrijvingenSearch.__xsd_schemas = \
-                    self._get_remote_xsd_schemas()
-
-            fields = self._build_fields(
-                LithologischeBeschrijvingenSearch.__wfs_schema,
-                LithologischeBeschrijvingenSearch.__fc_featurecatalogue,
-                LithologischeBeschrijvingenSearch.__xsd_schemas)
-
-            for field in fields.values():
-                if field['name'] not in self._type.get_field_names(
-                        include_wfs_injected=True):
-                    self._type.fields.append(
-                        _WfsInjectedField(name=field['name'],
-                                          datatype=field['type']))
-
-            self._fields = self._build_fields(
-                LithologischeBeschrijvingenSearch.__wfs_schema,
-                LithologischeBeschrijvingenSearch.__fc_featurecatalogue,
-                LithologischeBeschrijvingenSearch.__xsd_schemas)
-
-    def search(self, location=None, query=None, sort_by=None,
-               return_fields=None, max_features=None):
-        fts = self._search(location=location, query=query, sort_by=sort_by,
-                           return_fields=return_fields,
-                           max_features=max_features)
-
-        interpretaties = self._type.from_wfs(
-            fts, self.__wfs_namespace)
-
-        df = pd.DataFrame(
-            data=self._type.to_df_array(interpretaties, return_fields),
-            columns=self._type.get_field_names(return_fields))
-        return df
-
 
 class GecodeerdeLithologieSearch(AbstractSearch):
     """Search class to retrieve gecodeerde lithologie """
-
-    __wfs_schema = None
-    __wfs_namespace = None
-    __md_metadata = None
-    __fc_featurecatalogue = None
-    __xsd_schemas = None
 
     def __init__(self, objecttype=GecodeerdeLithologie):
         """Initialisation.
@@ -368,74 +103,9 @@ class GecodeerdeLithologieSearch(AbstractSearch):
             'interpretaties:gecodeerde_lithologie',
             objecttype)
 
-    def _init_namespace(self):
-        if GecodeerdeLithologieSearch.__wfs_namespace is None:
-            GecodeerdeLithologieSearch.__wfs_namespace = \
-                self._get_namespace()
-
-    def _init_fields(self):
-        if self._fields is None:
-            if GecodeerdeLithologieSearch.__wfs_schema is None:
-                GecodeerdeLithologieSearch.__wfs_schema = \
-                    self._get_schema()
-
-            if GecodeerdeLithologieSearch.__md_metadata is None:
-                GecodeerdeLithologieSearch.__md_metadata = \
-                    self._get_remote_metadata()
-
-            if GecodeerdeLithologieSearch.__fc_featurecatalogue \
-                    is None:
-                csw_url = self._get_csw_base_url()
-                fc_uuid = owsutil.get_featurecatalogue_uuid(
-                    GecodeerdeLithologieSearch.__md_metadata)
-
-                GecodeerdeLithologieSearch.__fc_featurecatalogue = \
-                    owsutil.get_remote_featurecatalogue(csw_url, fc_uuid)
-
-            if GecodeerdeLithologieSearch.__xsd_schemas is None:
-                GecodeerdeLithologieSearch.__xsd_schemas = \
-                    self._get_remote_xsd_schemas()
-
-            fields = self._build_fields(
-                GecodeerdeLithologieSearch.__wfs_schema,
-                GecodeerdeLithologieSearch.__fc_featurecatalogue,
-                GecodeerdeLithologieSearch.__xsd_schemas)
-
-            for field in fields.values():
-                if field['name'] not in self._type.get_field_names(
-                        include_wfs_injected=True):
-                    self._type.fields.append(
-                        _WfsInjectedField(name=field['name'],
-                                          datatype=field['type']))
-
-            self._fields = self._build_fields(
-                GecodeerdeLithologieSearch.__wfs_schema,
-                GecodeerdeLithologieSearch.__fc_featurecatalogue,
-                GecodeerdeLithologieSearch.__xsd_schemas)
-
-    def search(self, location=None, query=None, sort_by=None,
-               return_fields=None, max_features=None):
-        fts = self._search(location=location, query=query, sort_by=sort_by,
-                           return_fields=return_fields,
-                           max_features=max_features)
-
-        interpretaties = self._type.from_wfs(
-            fts, self.__wfs_namespace)
-
-        df = pd.DataFrame(
-            data=self._type.to_df_array(interpretaties, return_fields),
-            columns=self._type.get_field_names(return_fields))
-        return df
-
 
 class GeotechnischeCoderingSearch(AbstractSearch):
     """Search class to retrieve geotechnische codering """
-
-    __wfs_schema = None
-    __wfs_namespace = None
-    __md_metadata = None
-    __fc_featurecatalogue = None
-    __xsd_schemas = None
 
     def __init__(self, objecttype=GeotechnischeCodering):
         """Initialisation.
@@ -452,75 +122,10 @@ class GeotechnischeCoderingSearch(AbstractSearch):
             'interpretaties:geotechnische_coderingen',
             objecttype)
 
-    def _init_namespace(self):
-        if GeotechnischeCoderingSearch.__wfs_namespace is None:
-            GeotechnischeCoderingSearch.__wfs_namespace = \
-                self._get_namespace()
-
-    def _init_fields(self):
-        if self._fields is None:
-            if GeotechnischeCoderingSearch.__wfs_schema is None:
-                GeotechnischeCoderingSearch.__wfs_schema = \
-                    self._get_schema()
-
-            if GeotechnischeCoderingSearch.__md_metadata is None:
-                GeotechnischeCoderingSearch.__md_metadata = \
-                    self._get_remote_metadata()
-
-            if GeotechnischeCoderingSearch.__fc_featurecatalogue \
-                    is None:
-                csw_url = self._get_csw_base_url()
-                fc_uuid = owsutil.get_featurecatalogue_uuid(
-                    GeotechnischeCoderingSearch.__md_metadata)
-
-                GeotechnischeCoderingSearch.__fc_featurecatalogue = \
-                    owsutil.get_remote_featurecatalogue(csw_url, fc_uuid)
-
-            if GeotechnischeCoderingSearch.__xsd_schemas is None:
-                GeotechnischeCoderingSearch.__xsd_schemas = \
-                    self._get_remote_xsd_schemas()
-
-            fields = self._build_fields(
-                GeotechnischeCoderingSearch.__wfs_schema,
-                GeotechnischeCoderingSearch.__fc_featurecatalogue,
-                GeotechnischeCoderingSearch.__xsd_schemas)
-
-            for field in fields.values():
-                if field['name'] not in self._type.get_field_names(
-                        include_wfs_injected=True):
-                    self._type.fields.append(
-                        _WfsInjectedField(name=field['name'],
-                                          datatype=field['type']))
-
-            self._fields = self._build_fields(
-                GeotechnischeCoderingSearch.__wfs_schema,
-                GeotechnischeCoderingSearch.__fc_featurecatalogue,
-                GeotechnischeCoderingSearch.__xsd_schemas)
-
-    def search(self, location=None, query=None, sort_by=None,
-               return_fields=None, max_features=None):
-        fts = self._search(location=location, query=query, sort_by=sort_by,
-                           return_fields=return_fields,
-                           max_features=max_features)
-
-        interpretaties = self._type.from_wfs(
-            fts, self.__wfs_namespace)
-
-        df = pd.DataFrame(
-            data=self._type.to_df_array(interpretaties, return_fields),
-            columns=self._type.get_field_names(return_fields))
-        return df
-
 
 class QuartairStratigrafieSearch(AbstractSearch):
     """Search class to retrieve the interpretation for Quartair
     stratigrafie"""
-
-    __wfs_schema = None
-    __wfs_namespace = None
-    __md_metadata = None
-    __fc_featurecatalogue = None
-    __xsd_schemas = None
 
     def __init__(self, objecttype=QuartairStratigrafie):
         """Initialisation.
@@ -535,61 +140,6 @@ class QuartairStratigrafieSearch(AbstractSearch):
         """
         super(QuartairStratigrafieSearch, self).__init__(
             'interpretaties:quartaire_stratigrafie', objecttype)
-
-    def _init_namespace(self):
-        if QuartairStratigrafieSearch.__wfs_namespace is None:
-            QuartairStratigrafieSearch.__wfs_namespace = self._get_namespace()
-
-    def _init_fields(self):
-        if self._fields is None:
-            if QuartairStratigrafieSearch.__wfs_schema is None:
-                QuartairStratigrafieSearch.__wfs_schema = self._get_schema()
-
-            if QuartairStratigrafieSearch.__md_metadata is None:
-                QuartairStratigrafieSearch.__md_metadata = \
-                    self._get_remote_metadata()
-
-            if QuartairStratigrafieSearch.__fc_featurecatalogue is None:
-                csw_url = self._get_csw_base_url()
-                fc_uuid = owsutil.get_featurecatalogue_uuid(
-                    QuartairStratigrafieSearch.__md_metadata)
-
-                QuartairStratigrafieSearch.__fc_featurecatalogue = \
-                    owsutil.get_remote_featurecatalogue(csw_url, fc_uuid)
-
-            if QuartairStratigrafieSearch.__xsd_schemas is None:
-                QuartairStratigrafieSearch.__xsd_schemas = \
-                    self._get_remote_xsd_schemas()
-
-            fields = self._build_fields(
-                QuartairStratigrafieSearch.__wfs_schema,
-                QuartairStratigrafieSearch.__fc_featurecatalogue,
-                QuartairStratigrafieSearch.__xsd_schemas)
-
-            for field in fields.values():
-                if field['name'] not in self._type.get_field_names(
-                        include_wfs_injected=True):
-                    self._type.fields.append(
-                        _WfsInjectedField(name=field['name'],
-                                          datatype=field['type']))
-
-            self._fields = self._build_fields(
-                QuartairStratigrafieSearch.__wfs_schema,
-                QuartairStratigrafieSearch.__fc_featurecatalogue,
-                QuartairStratigrafieSearch.__xsd_schemas)
-
-    def search(self, location=None, query=None, sort_by=None,
-               return_fields=None, max_features=None):
-        fts = self._search(location=location, query=query, sort_by=sort_by,
-                           return_fields=return_fields,
-                           max_features=max_features)
-
-        interpretaties = self._type.from_wfs(fts, self.__wfs_namespace)
-
-        df = pd.DataFrame(
-            data=self._type.to_df_array(interpretaties, return_fields),
-            columns=self._type.get_field_names(return_fields))
-        return df
 
 
 class InformeleHydrogeologischeStratigrafieSearch(AbstractSearch):
@@ -606,81 +156,8 @@ class InformeleHydrogeologischeStratigrafieSearch(AbstractSearch):
 
     """
 
-    __wfs_schema = None
-    __wfs_namespace = None
-    __md_metadata = None
-    __fc_featurecatalogue = None
-    __xsd_schemas = None
-
     def __init__(self, objecttype=InformeleHydrogeologischeStratigrafie):
         """Initialisation."""
         super(InformeleHydrogeologischeStratigrafieSearch, self).__init__(
             'interpretaties:informele_hydrogeologische_stratigrafie',
             objecttype)
-
-    def _init_namespace(self):
-        if InformeleHydrogeologischeStratigrafieSearch.__wfs_namespace is None:
-            InformeleHydrogeologischeStratigrafieSearch.__wfs_namespace = \
-                self._get_namespace()
-
-    def _init_fields(self):
-        if self._fields is None:
-            if InformeleHydrogeologischeStratigrafieSearch.__wfs_schema is \
-                    None:
-                InformeleHydrogeologischeStratigrafieSearch.__wfs_schema = \
-                    self._get_schema()
-
-            if InformeleHydrogeologischeStratigrafieSearch.__md_metadata is \
-                    None:
-                InformeleHydrogeologischeStratigrafieSearch.__md_metadata = \
-                    self._get_remote_metadata()
-
-            if InformeleHydrogeologischeStratigrafieSearch.\
-                    __fc_featurecatalogue is None:
-                csw_url = self._get_csw_base_url()
-                fc_uuid = owsutil.get_featurecatalogue_uuid(
-                    InformeleHydrogeologischeStratigrafieSearch.__md_metadata)
-
-                InformeleHydrogeologischeStratigrafieSearch.\
-                    __fc_featurecatalogue = \
-                    owsutil.get_remote_featurecatalogue(csw_url, fc_uuid)
-
-            if InformeleHydrogeologischeStratigrafieSearch.__xsd_schemas is \
-                    None:
-                InformeleHydrogeologischeStratigrafieSearch.__xsd_schemas = \
-                    self._get_remote_xsd_schemas()
-
-            fields = self._build_fields(
-                InformeleHydrogeologischeStratigrafieSearch.__wfs_schema,
-                InformeleHydrogeologischeStratigrafieSearch.
-                __fc_featurecatalogue,
-                InformeleHydrogeologischeStratigrafieSearch.__xsd_schemas)
-
-            for field in fields.values():
-                if field['name'] not in self._type.get_field_names(
-                        include_wfs_injected=True):
-                    self._type.fields.append(
-                        _WfsInjectedField(name=field['name'],
-                                          datatype=field['type']))
-
-            self._fields = self._build_fields(
-                InformeleHydrogeologischeStratigrafieSearch.__wfs_schema,
-                InformeleHydrogeologischeStratigrafieSearch.
-                __fc_featurecatalogue,
-                InformeleHydrogeologischeStratigrafieSearch.__xsd_schemas)
-
-    def search(self, location=None, query=None, sort_by=None,
-               return_fields=None, max_features=None):
-        fts = self._search(location=location, query=query, sort_by=sort_by,
-                           return_fields=return_fields,
-                           max_features=max_features)
-
-        interpretaties = InformeleHydrogeologischeStratigrafie.from_wfs(
-            fts, self.__wfs_namespace)
-
-        df = pd.DataFrame(
-            data=InformeleHydrogeologischeStratigrafie.to_df_array(
-                interpretaties, return_fields),
-            columns=InformeleHydrogeologischeStratigrafie.get_field_names(
-                return_fields))
-        return df

--- a/pydov/search/sondering.py
+++ b/pydov/search/sondering.py
@@ -1,22 +1,12 @@
 # -*- coding: utf-8 -*-
 """Module containing the search classes to retrieve DOV CPT data."""
-import pandas as pd
-
 from pydov.search.abstract import AbstractSearch
-from pydov.types.fields import _WfsInjectedField
 from pydov.types.sondering import Sondering
-from pydov.util import owsutil
 
 
 class SonderingSearch(AbstractSearch):
     """Search class to retrieve information about CPT measurements (
     Sonderingen)."""
-
-    __wfs_schema = None
-    __wfs_namespace = None
-    __md_metadata = None
-    __fc_featurecatalogue = None
-    __xsd_schemas = None
 
     def __init__(self, objecttype=Sondering):
         """Initialisation.
@@ -31,57 +21,3 @@ class SonderingSearch(AbstractSearch):
         """
         super(SonderingSearch, self).__init__(
             'dov-pub:Sonderingen', objecttype)
-
-    def _init_namespace(self):
-        if SonderingSearch.__wfs_namespace is None:
-            SonderingSearch.__wfs_namespace = self._get_namespace()
-
-    def _init_fields(self):
-        if self._fields is None:
-            if SonderingSearch.__wfs_schema is None:
-                SonderingSearch.__wfs_schema = self._get_schema()
-
-            if SonderingSearch.__md_metadata is None:
-                SonderingSearch.__md_metadata = self._get_remote_metadata()
-
-            if SonderingSearch.__fc_featurecatalogue is None:
-                csw_url = self._get_csw_base_url()
-                fc_uuid = owsutil.get_featurecatalogue_uuid(
-                    SonderingSearch.__md_metadata)
-
-                SonderingSearch.__fc_featurecatalogue = \
-                    owsutil.get_remote_featurecatalogue(csw_url, fc_uuid)
-
-            if SonderingSearch.__xsd_schemas is None:
-                SonderingSearch.__xsd_schemas = \
-                    self._get_remote_xsd_schemas()
-
-            fields = self._build_fields(
-                SonderingSearch.__wfs_schema,
-                SonderingSearch.__fc_featurecatalogue,
-                SonderingSearch.__xsd_schemas)
-
-            for field in fields.values():
-                if field['name'] not in self._type.get_field_names(
-                        include_wfs_injected=True):
-                    self._type.fields.append(
-                        _WfsInjectedField(name=field['name'],
-                                          datatype=field['type']))
-
-            self._fields = self._build_fields(
-                SonderingSearch.__wfs_schema,
-                SonderingSearch.__fc_featurecatalogue,
-                SonderingSearch.__xsd_schemas)
-
-    def search(self, location=None, query=None, sort_by=None,
-               return_fields=None, max_features=None):
-        fts = self._search(location=location, query=query, sort_by=sort_by,
-                           return_fields=return_fields,
-                           max_features=max_features)
-
-        sonderingen = self._type.from_wfs(fts, self.__wfs_namespace)
-
-        df = pd.DataFrame(
-            data=self._type.to_df_array(sonderingen, return_fields),
-            columns=self._type.get_field_names(return_fields))
-        return df


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

This PR switches to workspace-level WFS endpoints for accessing the DOV feature types.

This change will benefit download size (and times) of the WFS capabilities, since the workspace-level endpoints will be a lot smaller than the main DOV WFS endpoint which now has over 2300 feature types.

As a result a lot of common code can also be removed: as there remains no large static data to share between search objects, more code can be moved into the abstract base class.

Closes #281
Closes #264
