### PR TITLE
Add missing Sondering fields

### DIFF
--- a/docs/output_fields.rst
+++ b/docs/output_fields.rst
@@ -184,6 +184,7 @@ CPT measurements (sonderingen)
     sondeernummer,1,string,GEO-02/079-S3
     x,1,float,142767
     y,1,float,221907
+    mv_mtaw,10,float,NaN
     start_sondering_mtaw,1,float,2.39
     diepte_sondering_van,1,float,0
     diepte_sondering_tot,1,float,16

--- a/docs/output_fields.rst
+++ b/docs/output_fields.rst
@@ -181,6 +181,7 @@ CPT measurements (sonderingen)
 
     Field,Cost,Datatype,Example
     pkey_sondering,1,string,https://www.dov.vlaanderen.be/data/sondering/2002-010317
+    sondeernummer,1,string,GEO-02/079-S3
     x,1,float,142767
     y,1,float,221907
     start_sondering_mtaw,1,float,2.39

--- a/pydov/types/sondering.py
+++ b/pydov/types/sondering.py
@@ -62,6 +62,12 @@ class Sondering(AbstractDovType):
                  datatype='string'),
         WfsField(name='x', source_field='X_mL72', datatype='float'),
         WfsField(name='y', source_field='Y_mL72', datatype='float'),
+        XmlField(name='mv_mtaw',
+                 source_xpath='/sondering/sondeerpositie/'
+                              'oorspronkelijk_maaiveld/waarde',
+                 definition='Maaiveldhoogte in mTAW op dag dat de boring '
+                            'uitgevoerd werd.',
+                 datatype='float'),
         WfsField(name='start_sondering_mtaw', source_field='Z_mTAW',
                  datatype='float'),
         WfsField(name='diepte_sondering_van', source_field='diepte_van_m',

--- a/pydov/types/sondering.py
+++ b/pydov/types/sondering.py
@@ -65,7 +65,7 @@ class Sondering(AbstractDovType):
         XmlField(name='mv_mtaw',
                  source_xpath='/sondering/sondeerpositie/'
                               'oorspronkelijk_maaiveld/waarde',
-                 definition='Maaiveldhoogte in mTAW op dag dat de boring '
+                 definition='Maaiveldhoogte in mTAW op dag dat de sondering '
                             'uitgevoerd werd.',
                  datatype='float'),
         WfsField(name='start_sondering_mtaw', source_field='Z_mTAW',

--- a/tests/test_search_sondering.py
+++ b/tests/test_search_sondering.py
@@ -39,7 +39,7 @@ class TestSonderingSearch(AbstractTestSearch):
     valid_returnfields_extra = ('pkey_sondering', 'conus')
 
     df_default_columns = [
-        'pkey_sondering', 'sondeernummer', 'x', 'y',
+        'pkey_sondering', 'sondeernummer', 'x', 'y', 'mv_mtaw',
         'start_sondering_mtaw', 'diepte_sondering_van',
         'diepte_sondering_tot', 'datum_aanvang', 'uitvoerder',
         'sondeermethode', 'apparaat', 'datum_gw_meting',

--- a/tests/test_types_sondering.py
+++ b/tests/test_types_sondering.py
@@ -17,7 +17,7 @@ class TestSondering(AbstractTestTypes):
     pkey_base = build_dov_url('data/sondering/')
 
     field_names = [
-        'pkey_sondering', 'sondeernummer', 'x', 'y',
+        'pkey_sondering', 'sondeernummer', 'x', 'y', 'mv_mtaw',
         'start_sondering_mtaw', 'diepte_sondering_van',
         'diepte_sondering_tot', 'datum_aanvang', 'uitvoerder',
         'sondeermethode', 'apparaat', 'datum_gw_meting',
@@ -25,7 +25,7 @@ class TestSondering(AbstractTestTypes):
     field_names_subtypes = [
         'lengte', 'diepte', 'qc', 'Qt', 'fs', 'u', 'i']
     field_names_nosubtypes = [
-        'pkey_sondering', 'sondeernummer', 'x', 'y',
+        'pkey_sondering', 'sondeernummer', 'x', 'y', 'mv_mtaw',
         'start_sondering_mtaw', 'diepte_sondering_van',
         'diepte_sondering_tot', 'datum_aanvang', 'uitvoerder',
         'sondeermethode', 'apparaat', 'datum_gw_meting',


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

This PR adds:
* the `sondeernummer` field to the documentation of the Sondering type
* the `mv_mtaw` field to the Sondering type and the documentation

Closes #289 
