### PR TITLE
Fix test failure due to rounding.

### DIFF
--- a/tests/test_search_grondmonster.py
+++ b/tests/test_search_grondmonster.py
@@ -97,6 +97,6 @@ class TestGrondmonsterSearch(AbstractTestSearch):
                 'volumemassa',
                 'watergehalte'))
 
-        assert df.korrelvolumemassa[0] == 2.65
-        assert df.volumemassa[0] == 1.627
-        assert df.watergehalte[0] == 57.7
+        assert round(df.korrelvolumemassa[0], 1) == 2.6
+        assert round(df.volumemassa[0], 1) == 1.6
+        assert round(df.watergehalte[0], 1) == 57.7


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

A change in the rounding of observation values in the XML export causes a test failure on the 'oefen' environment. Adjusted the test to ignore the rounding of values (the test is mostly there to check if the values are not NaN).
