### PR TITLE
Raise MetadataNotFoundError when remote metadata fails to be downloaded or parsed.

### DIFF
--- a/pydov/util/owsutil.py
+++ b/pydov/util/owsutil.py
@@ -90,7 +90,7 @@ def get_remote_metadata(contentmetadata):
         contentmetadata.parse_remote_metadata(pydov.util.net.request_timeout)
 
     for remote_md in contentmetadata.metadataUrls:
-        if 'metadata' in remote_md:
+        if 'metadata' in remote_md and remote_md['metadata'] is not None:
             return remote_md['metadata']
 
     raise MetadataNotFoundError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from owslib.etree import etree
 from owslib.feature.schema import _construct_schema, _get_elements
+from owslib.feature.wfs110 import ContentMetadata
 from owslib.iso import MD_Metadata
 from owslib.util import ResponseWrapper, findall
 from owslib.wfs import WebFeatureService
@@ -340,6 +341,25 @@ def mp_dov_xml_broken(monkeypatch):
 
     monkeypatch.setattr(pydov.types.abstract.AbstractDovType,
                         '_get_xml_data', _get_xml_data)
+
+
+@pytest.fixture()
+def mp_geonetwork_broken(monkeypatch):
+    """Monkeypatch the parsing of remote metadata to simulate the case where
+    this would fail.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.fixture
+        PyTest monkeypatch fixture.
+    """
+
+    def _parse_remote_metadata(self, *args, **kwargs):
+        for metadataUrl in self.metadataUrls:
+            metadataUrl["metadata"] = None
+
+    monkeypatch.setattr(ContentMetadata,
+                        'parse_remote_metadata', _parse_remote_metadata)
 
 
 @pytest.fixture()

--- a/tests/test_util_owsutil_no_mp.py
+++ b/tests/test_util_owsutil_no_mp.py
@@ -29,3 +29,20 @@ class TestOwsutilNoMP(object):
         contentmetadata.metadataUrls = []
         with pytest.raises(MetadataNotFoundError):
             owsutil.get_remote_metadata(contentmetadata)
+
+    def test_get_remote_metadata_nometadata(self, wfs, mp_geonetwork_broken):
+        """Test the owsutil.get_remote_metadata method when the remote metadata
+        could not be found.
+
+        Test whether a MetadataNotFoundError is raised.
+
+        Parameters
+        ----------
+        wfs : pytest.fixture returning owslib.wfs.WebFeatureService
+            WebFeatureService based on the local GetCapabilities.
+
+        """
+        contents = copy.deepcopy(wfs.contents)
+        contentmetadata = contents['dov-pub:Boringen']
+        with pytest.raises(MetadataNotFoundError):
+            owsutil.get_remote_metadata(contentmetadata)


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Currently this leads to an (ugly) AttributeError (see #355), while we have MetadataNotFoundError for cases like this.