### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   tests-linux:
     name: "Tests on ${{ matrix.python-version }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +38,7 @@ jobs:
   tests-windows:
     name: "Tests on ${{ matrix.python-version }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -62,7 +62,7 @@ jobs:
   tests-conda:
     name: "Tests with conda (${{ matrix.python-version }} on ${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -104,7 +104,7 @@ jobs:
   update-data:
     name: "Updated data on ${{ matrix.python-version }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -129,7 +129,7 @@ jobs:
   flake8:
     name: "Flake8 on ${{ matrix.python-version }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -154,7 +154,7 @@ jobs:
   docs:
     name: "Docs on ${{ matrix.python-version }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -42,11 +42,8 @@ you through the process.
     give the following a try:
 
     #. Install `pipwin`_ using :code:`pip install pipwin`
-    #. Using pipwin, download the latest Windows binaries for GDAL, Fiona and GeoPandas provided by `Christoph Gohlke`_:
-
-      #. Install `GDAL`_ with :code:`pipwin install gdal`
-      #. Install `Fiona`_ with :code:`pipwin install fiona`
-      #. Install `GeoPandas`_ with :code:`pipwin install geopandas`
+    #. Using pipwin, install the latest Windows binaries for GDAL using :code:`pipwin install gdal`
+    #. Install pydov's vectorfile dependencies with :code:`pip install pydov[vectorfile]`
 
 .. _Fiona: https://pypi.org/project/Fiona/
 .. _GDAL: https://gdal.org/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,20 +36,12 @@ you through the process.
 
         pip install pydov[vectorfile]
 
-    Installing these package on Windows can be cumbersome. Please consult the installation guides of the
-    different packages. If you are using conda, pre-install them with :code:`conda install -c conda-forge fiona geopandas`
-    in your pydov conda environment before running the pydov installation. If you are not using conda,
-    give the following a try:
-
-    #. Install `pipwin`_ using :code:`pip install pipwin`
-    #. Using pipwin, install the latest Windows binaries for GDAL using :code:`pipwin install gdal`
-    #. Install pydov's vectorfile dependencies with :code:`pip install pydov[vectorfile]`
+    If you are using conda, you can also pre-install them with :code:`conda install -c conda-forge fiona geopandas`
+    in your pydov conda environment before running the pydov installation.
 
 .. _Fiona: https://pypi.org/project/Fiona/
 .. _GDAL: https://gdal.org/
 .. _GeoPandas: https://geopandas.org/
-.. _Pipwin: https://pypi.org/project/pipwin/
-.. _Christoph Gohlke: https://www.lfd.uci.edu/~gohlke/pythonlibs/
 
 From sources
 ------------

--- a/docs/network_proxy.rst
+++ b/docs/network_proxy.rst
@@ -39,13 +39,7 @@ Or, when you need the proxy to install remote packages via pip as well::
 
 .. note::
 
-    On Windows, it might be easier to install the dukpy JavaScript interpreter from a binary wheel using pipwin rather than building it from source.
-
-        #. First, install pipwin with :code:`pip install --proxy http://url-of-proxy.server:port pipwin`
-        #. Then, install dukpy with pipwin: :code:`pipwin install --proxy http://url-of-proxy.server:port dukpy`
-        #. Lastly, install pydov with proxy support using :code:`pip install --proxy http://url-of-proxy.server:port pydov[proxy]`
-
-    Or, if you are using conda:
+    If you are using conda you can also install the dukpy dependency through conda first:
 
         #. Configure proxy servers in conda::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-owslib < 0.26;python_version>='3.10'
-owslib;python_version<'3.10'
+owslib < 0.26;python_version>="3.10"
+owslib;python_version<"3.10"
 pandas
 numpy
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-owslib
+owslib < 0.26;python_version>='3.10'
+owslib;python_version<'3.10'
 pandas
 numpy
 requests

--- a/requirements_vectorfile.txt
+++ b/requirements_vectorfile.txt
@@ -1,4 +1,2 @@
-gdal ; sys_platform == 'win32'
-shapely ; sys_platform == 'win32'
 fiona==1.9a2
 geopandas

--- a/requirements_vectorfile.txt
+++ b/requirements_vectorfile.txt
@@ -1,4 +1,4 @@
 gdal ; sys_platform == 'win32'
 shapely ; sys_platform == 'win32'
-fiona>=1.8.18
+fiona==1.9a2
 geopandas

--- a/tox.ini
+++ b/tox.ini
@@ -36,11 +36,9 @@ setenv =
 deps =
     -r{toxinidir}/requirements_dev.txt
     -r{toxinidir}/requirements_proxy.txt
-    pipwin
+    -r {toxinidir}/requirements_vectorfile.txt
     lxml: lxml
 commands =
-    pipwin refresh
-    pipwin install -r {toxinidir}/requirements_vectorfile.txt
     py.test --basetemp={envtmpdir} --cov=pydov
 
 [testenv:{py37,py38,py39,py310}-{lxml,nolxml}-others]

--- a/tox.ini
+++ b/tox.ini
@@ -36,10 +36,8 @@ setenv =
 deps =
     -r{toxinidir}/requirements_dev.txt
     -r{toxinidir}/requirements_proxy.txt
-    pipwin
     lxml: lxml
 commands =
-    pipwin install gdal
     pip install -r {toxinidir}/requirements_vectorfile.txt
     py.test --basetemp={envtmpdir} --cov=pydov
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,9 +36,11 @@ setenv =
 deps =
     -r{toxinidir}/requirements_dev.txt
     -r{toxinidir}/requirements_proxy.txt
-    -r {toxinidir}/requirements_vectorfile.txt
+    pipwin
     lxml: lxml
 commands =
+    pipwin install gdal
+    pip install -r {toxinidir}/requirements_vectorfile.txt
     py.test --basetemp={envtmpdir} --cov=pydov
 
 [testenv:{py37,py38,py39,py310}-{lxml,nolxml}-others]


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

This PR fixes the build by switching to the new Fiona 1.9 (alpha for now) that has binary wheel available for Windows too.  This way we can also remove the pipwin installed wheels whose future is unsure.

Also we pin OWSLib to a version before 0.26 on Python >= 3.10, since 0.26 depends on an old pyproj that has no binary wheels for recent Python versions. Hopefully this will be fixed in a future OWSLib version.
