### PR TITLE
Don't build universal wheels as we're Py3 only these days.

### DIFF
--- a/pydov/util/net.py
+++ b/pydov/util/net.py
@@ -61,12 +61,12 @@ def proxy_autoconfiguration():
             Proxy server to use for HTTPS, ot None to disable.
         """
         if orig_http_proxy is None:
-            del(os.environ['HTTP_PROXY'])
+            del os.environ['HTTP_PROXY']
         else:
             os.environ['HTTP_PROXY'] = orig_http_proxy
 
         if orig_https_proxy is None:
-            del(os.environ['HTTPS_PROXY'])
+            del os.environ['HTTPS_PROXY']
         else:
             os.environ['HTTPS_PROXY'] = orig_https_proxy
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,6 @@ replace = version='{new_version}'
 search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
 
-[bdist_wheel]
-universal = 1
-
 [flake8]
 exclude = docs
 


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Universal wheels are for Python2 and Python3, and we're no longer supporting Python2 for quite a while now.