### PR TITLE
Drop support for Python3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v1"
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v1"
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: "actions/checkout@v2"
       - uses: conda-incubator/setup-miniconda@v2
@@ -109,7 +109,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8"]
+        python-version: ["3.9"]
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v1"
@@ -134,7 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8"]
+        python-version: ["3.9"]
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v1"
@@ -159,7 +159,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8"]
+        python-version: ["3.9"]
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v1"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: "3.7"
+          python-version: "3.9"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,12 @@ History
 v3.0.0 (unreleased)
 -------------------
 
+* News
+
+  * This version drops support for Python 3.7.
+
+  * This version is supported on Python 3.8, 3.9 and 3.10.
+
 * Breaking changes
 
   * pydov3 uses WFS 2.0.0 instead of WFS 1.1.0, as a consequence attribute filters

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
             'Natural Language :: English',
             'Natural Language :: Dutch',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,19 @@
 [tox]
-envlist = {py37,py38,py39,py310}-{lxml,nolxml}-{windows,others}, update-oefen, update-productie, flake8, docs
+envlist = {py38,py39,py310}-{lxml,nolxml}-{windows,others}, update-oefen, update-productie, flake8, docs
 
 [gh-actions]
 python =
     3.10: py310
     3.9: py39
     3.8: py38
-    3.7: py37
 
 [testenv:flake8]
-basepython=python3.8
+basepython=python3.9
 deps=flake8
 commands=flake8 pydov
 
 [testenv:docs]
-basepython=python3.8
+basepython=python3.9
 passenv = *
 whitelist_externals=/usr/bin/pandoc
 deps =
@@ -24,10 +23,9 @@ commands=
     pandoc -v
     sphinx-build -b html docs docs/_build
 
-[testenv:{py37,py38,py39,py310}-{lxml,nolxml}-windows]
+[testenv:{py38,py39,py310}-{lxml,nolxml}-windows]
 platform = win32
 basepython =
-    py37: python3.7
     py38: python3.8
     py39: python3.9
     py310: python3.10
@@ -41,10 +39,9 @@ commands =
     pip install -r {toxinidir}/requirements_vectorfile.txt
     py.test --basetemp={envtmpdir} --cov=pydov
 
-[testenv:{py37,py38,py39,py310}-{lxml,nolxml}-others]
+[testenv:{py38,py39,py310}-{lxml,nolxml}-others]
 platform = linux|darwin
 basepython =
-    py37: python3.7
     py38: python3.8
     py39: python3.9
     py310: python3.10
@@ -58,7 +55,7 @@ commands =
     py.test --basetemp={envtmpdir} --cov=pydov
 
 [testenv:update-oefen]
-basepython=python3.8
+basepython=python3.9
 setenv =
     PYTHONPATH = {toxinidir}
     PYDOV_BASE_URL = https://oefen.dov.vlaanderen.be/
@@ -71,7 +68,7 @@ commands =
     py.test --basetemp={envtmpdir} --cov=pydov
 
 [testenv:update-productie]
-basepython=python3.8
+basepython=python3.9
 setenv =
     PYTHONPATH = {toxinidir}
 deps =


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Python 3.7.15 includes an upgrade of libexpat which appears to break some XML parsing functionality. We will not investigate this further and drop support for Python3.7 from pydov 3.0.0 onwards. Recent pandas already dropped support for Python3.7 some time ago.
