### PR TITLE
Disable XML entity resolving in lxml.

### DIFF
--- a/pydov/util/dovutil.py
+++ b/pydov/util/dovutil.py
@@ -127,7 +127,8 @@ def parse_dov_xml(xml_data):
 
     """
     try:
-        parser = etree.XMLParser(ns_clean=True, recover=True)
+        parser = etree.XMLParser(
+            ns_clean=True, recover=True, resolve_entities=False)
     except TypeError:
         parser = etree.XMLParser()
 


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Following the 0.28.1 OWSLib security release, also disable XML entity resolving when using lxml's XMLParser in pydov.
