### PR TITLE
Remove nolxml test environments from CI.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py38,py39,py310,py311}-{lxml,nolxml}-{windows,others}, update-oefen, update-productie, flake8, docs
+envlist = {py38,py39,py310,py311}-{windows,others}, update-oefen, update-productie, flake8, docs
 
 [gh-actions]
 python =
@@ -24,7 +24,7 @@ commands=
     pandoc -v
     sphinx-build -b html docs docs/_build
 
-[testenv:{py38,py39,py310,py311}-{lxml,nolxml}-windows]
+[testenv:{py38,py39,py310,py311}-windows]
 platform = win32
 basepython =
     py38: python3.8
@@ -36,12 +36,11 @@ setenv =
 deps =
     -r{toxinidir}/requirements_dev.txt
     -r{toxinidir}/requirements_proxy.txt
-    lxml: lxml
 commands =
     pip install -r {toxinidir}/requirements_vectorfile.txt
     py.test --basetemp={envtmpdir} --cov=pydov
 
-[testenv:{py38,py39,py310,py311}-{lxml,nolxml}-others]
+[testenv:{py38,py39,py310,py311}-others]
 platform = linux|darwin
 basepython =
     py38: python3.8
@@ -53,7 +52,6 @@ setenv =
 deps =
     -r{toxinidir}/requirements_dev.txt
     -r{toxinidir}/requirements_vectorfile.txt
-    lxml: lxml
 commands =
     py.test --basetemp={envtmpdir} --cov=pydov
 
@@ -65,7 +63,6 @@ setenv =
 deps =
     -r{toxinidir}/requirements_dev.txt
     -r{toxinidir}/requirements_vectorfile.txt
-    lxml
 commands =
     python {toxinidir}/tests/data/update_test_data.py
     py.test --basetemp={envtmpdir} --cov=pydov
@@ -77,7 +74,6 @@ setenv =
 deps =
     -r{toxinidir}/requirements_dev.txt
     -r{toxinidir}/requirements_vectorfile.txt
-    lxml
 commands =
     python {toxinidir}/tests/data/update_test_data.py
     py.test --basetemp={envtmpdir} --cov=pydov


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Since OWSLib requires lxml from 0.28.1 onwards, we can remove the `nolxml` test environments from CI.
