### PR TITLE
Fix GMLObject tests.

### DIFF
--- a/tests/test_util_location.py
+++ b/tests/test_util_location.py
@@ -218,13 +218,12 @@ class TestLocation(object):
         Test whether an ValueError is raised.
 
         """
-        with open('tests/data/types/boring/boring.xml', 'r') as xmlfile:
+        with open('tests/data/types/interpretaties/gecodeerde_lithologie/'
+                  'gecodeerde_lithologie.xml', 'r') as xmlfile:
             xml = xmlfile.read()
 
-            with pytest.raises(ValueError) as error:
+            with pytest.raises(ValueError, match='not to be valid GML3.2'):
                 GmlObject(xml)
-
-                assert 'not to be valid GML3.2' in error
 
     def test_gmlobject_old_gml(self):
         """Test the GmlObject type with XML that is GML 3.1.1
@@ -236,10 +235,8 @@ class TestLocation(object):
                   'r') as xmlfile:
             xml = xmlfile.read()
 
-            with pytest.raises(ValueError) as error:
+            with pytest.raises(ValueError, match='older'):
                 GmlObject(xml)
-
-                assert 'older' in error
 
 
 class TestBinarySpatialFilters(object):


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Since the Boring XML export now encodes the location as GML, we can no longer use it as an invalid GML. Switch to Interpretatie XML that contains no location at all, so will definitely be invalid GML.
