### PR TITLE
Introduce PropertyLikeList and FuzzyJoin query utilities.

### DIFF
--- a/pydov/util/query.py
+++ b/pydov/util/query.py
@@ -66,7 +66,8 @@ class PropertyLikeList(OgcExpression):
     Internally translates to an Or combination of PropertyIsLike
     expressions:
 
-    PropertyLikeList('methode', ['spade', 'spoelboring'], '%{item}%') is equivalent to
+    PropertyLikeList('methode', ['spade', 'spoelboring'], '%{item}%') is
+    equivalent to
 
     Or([PropertyIsLike('methode', '%spade%'), PropertyIsLike('methode',
     '%spoelboring%')])
@@ -83,8 +84,9 @@ class PropertyLikeList(OgcExpression):
         lst : list of str
             List of item literals to match against.
         modifier : str
-            Optional, modifier to apply to the lst items when constructing the query.
-            You can use the string '{item}' in it which will be replaced by the lst item.
+            Optional, modifier to apply to the lst items when constructing the
+            query. You can use the string '{item}' in it which will be replaced
+            by the lst item.
 
         Raises
         ------
@@ -108,7 +110,8 @@ class PropertyLikeList(OgcExpression):
                 propertyname, modifier.format(item=set(lst).pop()))
         else:
             self.query = Or(
-                [PropertyIsLike(propertyname, modifier.format(item=i)) for i in sorted(set(lst))])
+                [PropertyIsLike(propertyname, modifier.format(item=i)) for i
+                 in sorted(set(lst))])
 
     def toXML(self):
         """Return the XML representation of the PropertyInList query.
@@ -126,7 +129,8 @@ class AbstractJoin:
     """Abstract base class for the Join classes."""
 
     def _is_iterable_type(self, dataframe, column):
-        """Check if the first element in a specified column of a dataframe is an iterable type (list or set).
+        """Check if the first element in a specified column of a dataframe is
+        an iterable type (list or set).
 
         Parameters
         ----------
@@ -138,7 +142,8 @@ class AbstractJoin:
         Returns
         -------
         bool
-            True if the first element of the column is a list or set, False otherwise.
+            True if the first element of the column is a list or set, False
+            otherwise.
 
         Raises
         ------
@@ -152,8 +157,9 @@ class AbstractJoin:
             isinstance(dataframe[column].iloc[0], set)
 
     def _get_unique_value_list(self, dataframe, column):
-        """Retrieve a list of unique values from a specified column in a pandas DataFrame. 
-        If the values are iterable (list or set), it aggregates them.
+        """Retrieve a list of unique values from a specified column in a pandas
+        DataFrame. If the values are iterable (list or set), it aggregates
+        them.
 
         Parameters
         ----------
@@ -165,7 +171,8 @@ class AbstractJoin:
         Returns
         -------
         list
-            A list of unique values from the specified column, possibly aggregating iterable values.
+            A list of unique values from the specified column, possibly
+            aggregating iterable values.
 
         Raises
         ------
@@ -237,14 +244,16 @@ class Join(AbstractJoin, PropertyInList):
 
 
 class FuzzyJoin(AbstractJoin, PropertyLikeList):
-    """Filter expression to join different searches together in a fuzzy (non-exact) way.
+    """Filter expression to join different searches together in a fuzzy
+    (non-exact) way.
 
     Internally translates to a PropertyLikeList:
 
     FuzzyJoin(df, 'pkey_boring', modifier='%|{item}|%') is equivalent to
 
-    PropertyLikeList('pkey_boring', list(df['pkey_boring'), modifier='%|{item}|%') which is
-    equivalent to
+    PropertyLikeList('pkey_boring', list(df['pkey_boring'),
+                     modifier='%|{item}|%')
+    which is equivalent to
 
     Or([PropertyIsLike('pkey_boring', '%|x|%'), PropertyIsLike(
     'pkey_boring', '%|y|%'), ...]) for every x, y, in df['pkey_boring']
@@ -264,8 +273,9 @@ class FuzzyJoin(AbstractJoin, PropertyLikeList):
             Name of the column in the dataframe to use for joining. By
             default, the same column name as in `on` is assumed.
         modifier : str, optional, defaults to `'%|{item}|%'`
-            Optional, modifier to apply to the dataframe items when constructing the query.
-            You can use the string '{item}' in it which will be replaced by the dataframe item.
+            Optional, modifier to apply to the dataframe items when
+            constructing the query. You can use the string '{item}' in it which
+            will be replaced by the dataframe item.
 
         Raises
         ------

--- a/pydov/util/query.py
+++ b/pydov/util/query.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Module containing extra query classes to build attribute search queries."""
 
-from owslib.fes2 import OgcExpression, Or, PropertyIsEqualTo
+from owslib.fes2 import OgcExpression, Or, PropertyIsEqualTo, PropertyIsLike
 
 
 class PropertyInList(OgcExpression):
@@ -59,7 +59,127 @@ class PropertyInList(OgcExpression):
         return self.query.toXML()
 
 
-class Join(PropertyInList):
+class PropertyLikeList(OgcExpression):
+    """Filter expression to test whether a given property is like one of the
+    values from a list.
+
+    Internally translates to an Or combination of PropertyIsLike
+    expressions:
+
+    PropertyLikeList('methode', ['spade', 'spoelboring'], '%{item}%') is equivalent to
+
+    Or([PropertyIsLike('methode', '%spade%'), PropertyIsLike('methode',
+    '%spoelboring%')])
+
+    """
+
+    def __init__(self, propertyname, lst, modifier='%{item}%'):
+        """Initialisation.
+
+        Parameters
+        ----------
+        propertyname : str
+            Name of the attribute to query.
+        lst : list of str
+            List of item literals to match against.
+        modifier : str
+            Optional, modifier to apply to the lst items when constructing the query.
+            You can use the string '{item}' in it which will be replaced by the lst item.
+
+        Raises
+        ------
+        ValueError
+            If the given list does not contain at least a single item.
+            If the modifier is not of type str.
+
+        """
+        super(PropertyLikeList, self).__init__()
+
+        if not isinstance(lst, list) and not isinstance(lst, set):
+            raise ValueError('list should be of type "list" or "set"')
+
+        if not isinstance(modifier, str):
+            raise ValueError('modifier should be of type "str"')
+
+        if len(set(lst)) < 1:
+            raise ValueError('list should contain at least a single item')
+        elif len(set(lst)) == 1:
+            self.query = PropertyIsLike(
+                propertyname, modifier.format(item=set(lst).pop()))
+        else:
+            self.query = Or(
+                [PropertyIsLike(propertyname, modifier.format(item=i)) for i in sorted(set(lst))])
+
+    def toXML(self):
+        """Return the XML representation of the PropertyInList query.
+
+        Returns
+        -------
+        xml : etree.ElementTree
+            XML representation of the PropertyInList
+
+        """
+        return self.query.toXML()
+
+
+class AbstractJoin:
+    """Abstract base class for the Join classes."""
+
+    def _is_iterable_type(self, dataframe, column):
+        """Check if the first element in a specified column of a dataframe is an iterable type (list or set).
+
+        Parameters
+        ----------
+        dataframe : pandas.DataFrame
+            A pandas DataFrame containing the data.
+        column : str
+            The name of the column to check.
+
+        Returns
+        -------
+        bool
+            True if the first element of the column is a list or set, False otherwise.
+
+        Raises
+        ------
+        ValueError
+            If the input dataframe is empty.
+        """
+        if len(dataframe) < 1:
+            raise ValueError("dataframe should not be empty")
+
+        return isinstance(dataframe[column].iloc[0], list) or \
+            isinstance(dataframe[column].iloc[0], set)
+
+    def _get_unique_value_list(self, dataframe, column):
+        """Retrieve a list of unique values from a specified column in a pandas DataFrame. 
+        If the values are iterable (list or set), it aggregates them.
+
+        Parameters
+        ----------
+        dataframe : pandas.DataFrame
+            A pandas DataFrame containing the data.
+        column : str
+            The name of the column to process.
+
+        Returns
+        -------
+        list
+            A list of unique values from the specified column, possibly aggregating iterable values.
+
+        Raises
+        ------
+        ValueError
+            If the input dataframe is empty.
+        """
+        if self._is_iterable_type(dataframe, column):
+            value_list = dataframe[column].dropna().aggregate('sum')
+            return list(set(value_list))
+
+        return list(dataframe[column].dropna().unique())
+
+
+class Join(AbstractJoin, PropertyInList):
     """Filter expression to join different searches together.
 
     Internally translates to a PropertyInList:
@@ -107,10 +227,70 @@ class Join(PropertyInList):
                 "column '{}' should be present in the dataframe.".format(
                     using))
 
-        value_list = list(dataframe[using].dropna().unique())
+        value_list = self._get_unique_value_list(dataframe, using)
 
         if len(set(value_list)) < 1:
             raise ValueError("dataframe should contain at least a single "
                              "value in column '{}'.".format(using))
 
         super(Join, self).__init__(on, value_list)
+
+
+class FuzzyJoin(AbstractJoin, PropertyLikeList):
+    """Filter expression to join different searches together in a fuzzy (non-exact) way.
+
+    Internally translates to a PropertyLikeList:
+
+    FuzzyJoin(df, 'pkey_boring', modifier='%|{item}|%') is equivalent to
+
+    PropertyLikeList('pkey_boring', list(df['pkey_boring'), modifier='%|{item}|%') which is
+    equivalent to
+
+    Or([PropertyIsLike('pkey_boring', '%|x|%'), PropertyIsLike(
+    'pkey_boring', '%|y|%'), ...]) for every x, y, in df['pkey_boring']
+
+    """
+
+    def __init__(self, dataframe, on, using=None, modifier='%|{item}|%'):
+        """Initialisation.
+
+        Parameters
+        ----------
+        dataframe : pandas.DataFrame
+            Dataframe to use a basis for joining.
+        on : str
+            Name of the column in the queried datatype to join on.
+        using : str, optional
+            Name of the column in the dataframe to use for joining. By
+            default, the same column name as in `on` is assumed.
+        modifier : str, optional, defaults to `'%|{item}|%'`
+            Optional, modifier to apply to the dataframe items when constructing the query.
+            You can use the string '{item}' in it which will be replaced by the dataframe item.
+
+        Raises
+        ------
+        ValueError
+            If the `using` column is not present in the dataframe.
+
+            If `using` is None and the `on` column is not present in the
+            dataframe.
+
+            If the dataframe does not contain at least a single non-null value
+            in the `using` column.
+
+        """
+        if using is None:
+            using = on
+
+        if using not in list(dataframe):
+            raise ValueError(
+                "column '{}' should be present in the dataframe.".format(
+                    using))
+
+        value_list = self._get_unique_value_list(dataframe, using)
+
+        if len(set(value_list)) < 1:
+            raise ValueError("dataframe should contain at least a single "
+                             "value in column '{}'.".format(using))
+
+        super(FuzzyJoin, self).__init__(on, value_list, modifier)

--- a/tests/test_util_query.py
+++ b/tests/test_util_query.py
@@ -7,7 +7,7 @@ import pytest
 from owslib.etree import etree
 
 from pydov.util.dovutil import build_dov_url
-from pydov.util.query import Join, PropertyInList
+from pydov.util.query import FuzzyJoin, Join, PropertyInList, PropertyLikeList
 from tests.abstract import clean_xml
 
 
@@ -163,6 +163,192 @@ class TestPropertyInList(object):
         with pytest.raises(ValueError):
             l = 'goed'
             PropertyInList('betrouwbaarheid', l)
+
+
+class TestPropertyLikeList(object):
+    """Test the PropertyLikeList query expression."""
+
+    def test(self):
+        """Test the PropertyLikeList expression with a standard list and modifier.
+
+        Test whether the generated query is correct.
+
+        """
+        l = ['a', 'b', 'c']
+        l_modified = ['%a%', '%b%', '%c%']
+
+        query = PropertyLikeList('methode', l)
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/fes/2.0}Or'
+        assert len(list(xml)) == 3
+
+        for f in xml:
+            assert f.tag == '{http://www.opengis.net/fes/2.0}PropertyIsLike'
+
+            valuereference = f.find(
+                './{http://www.opengis.net/fes/2.0}ValueReference')
+            assert valuereference.text == 'methode'
+
+            literal = f.find('./{http://www.opengis.net/fes/2.0}Literal')
+            assert literal.text in l_modified
+
+            l_modified.remove(literal.text)
+
+        assert len(l_modified) == 0
+
+    def test_modifier(self):
+        """Test the PropertyLikeList expression with a standard list and custom modifier.
+
+        Test whether the generated query is correct.
+
+        """
+        l = ['a', 'b', 'c']
+        l_modified = ['%|a|%', '%|b|%', '%|c|%']
+
+        query = PropertyLikeList('methode', l, modifier='%|{item}|%')
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/fes/2.0}Or'
+        assert len(list(xml)) == 3
+
+        for f in xml:
+            assert f.tag == '{http://www.opengis.net/fes/2.0}PropertyIsLike'
+
+            valuereference = f.find(
+                './{http://www.opengis.net/fes/2.0}ValueReference')
+            assert valuereference.text == 'methode'
+
+            literal = f.find('./{http://www.opengis.net/fes/2.0}Literal')
+            assert literal.text in l_modified
+
+            l_modified.remove(literal.text)
+
+        assert len(l_modified) == 0
+
+    def test_stable(self):
+        """Test the PropertyLikeList expression with a standard list and modifier.
+
+        Test whether the generated query is correct and stable.
+
+        """
+        l = ['a', 'b', 'c']
+
+        for p in permutations(l):
+            query = PropertyLikeList('methode', list(p))
+            xml = query.toXML()
+
+            assert clean_xml(etree.tostring(xml).decode('utf8')) == clean_xml(
+                '<fes:Or><fes:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\\">'
+                '<fes:ValueReference>methode</fes:ValueReference><ogc:Literal>%a%</fes:Literal>'
+                '</fes:PropertyIsLike><fes:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\\">'
+                '<fes:ValueReference>methode</fes:ValueReference><ogc:Literal>%b%</fes:Literal>'
+                '</fes:PropertyIsLike><fes:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\\">'
+                '<fes:ValueReference>methode</fes:ValueReference><fes:Literal>%c%</fes:Literal>'
+                '</fes:PropertyIsLike></fes:Or>')
+
+    def test_duplicate(self):
+        """Test the PropertyLikeList expression with a list containing
+        duplicates.
+
+        Test whether the generated query is correct and does not contain the
+        duplicate entry twice.
+
+        """
+        l = ['a', 'a', 'b', 'c']
+        l_modified = ['%a%', '%b%', '%c%']
+
+        query = PropertyLikeList('methode', l)
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/fes/2.0}Or'
+        assert len(list(xml)) == 3
+
+        for f in xml:
+            assert f.tag == '{http://www.opengis.net/fes/2.0}PropertyIsLike'
+
+            valuereference = f.find(
+                './{http://www.opengis.net/fes/2.0}ValueReference')
+            assert valuereference.text == 'methode'
+
+            literal = f.find('./{http://www.opengis.net/fes/2.0}Literal')
+            assert literal.text in l_modified
+
+            l_modified.remove(literal.text)
+
+        assert len(l_modified) == 0
+
+    def test_list_single(self):
+        """Test the PropertyLikeList expression with a list containing
+        a single item.
+
+        Test whether the generated query is correct and does contain only a
+        single PropertyIsLike.
+
+        """
+        l = ['a']
+        l_modified = ['%a%']
+
+        query = PropertyLikeList('methode', l)
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/fes/2.0}PropertyIsLike'
+
+        valuereference = xml.find(
+            './{http://www.opengis.net/fes/2.0}ValueReference')
+        assert valuereference.text == 'methode'
+
+        literal = xml.find('./{http://www.opengis.net/fes/2.0}Literal')
+        assert literal.text in l_modified
+
+        l_modified.remove(literal.text)
+        assert len(l_modified) == 0
+
+    def test_list_single_duplicate(self):
+        """Test the PropertyLikeList expression with a list containing
+        a single duplicated item.
+
+        Test whether the generated query is correct and does contain only a
+        single PropertyIsLike.
+
+        """
+        l = ['a', 'a']
+        l_modified = ['%a%']
+
+        query = PropertyLikeList('methode', l)
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/fes/2.0}PropertyIsLike'
+
+        valuereference = xml.find(
+            './{http://www.opengis.net/fes/2.0}ValueReference')
+        assert valuereference.text == 'methode'
+
+        literal = xml.find('./{http://www.opengis.net/fes/2.0}Literal')
+        assert literal.text in l_modified
+
+        l_modified.remove(literal.text)
+        assert len(l_modified) == 0
+
+    def test_emptylist(self):
+        """Test the PropertyLikeList expression with an empty list.
+
+        Test whether a ValueError is raised.
+
+        """
+        with pytest.raises(ValueError):
+            l = []
+            PropertyLikeList('methode', l)
+
+    def test_nolist(self):
+        """Test the PropertyLikeList expression with a string instead of a list.
+
+        Test whether a ValueError is raised.
+
+        """
+        with pytest.raises(ValueError):
+            l = 'goed'
+            PropertyLikeList('betrouwbaarheid', l)
 
 
 class TestJoin(object):
@@ -406,3 +592,261 @@ class TestJoin(object):
             l.remove(literal.text)
 
         assert len(l) == 0
+
+
+class TestFuzzyJoin(object):
+    """Test the FuzzyJoin query expression."""
+
+    def test(self):
+        """Test the FuzzyJoin expression with a standard dataframe and modifier.
+
+        Test whether the generated query is correct.
+
+        """
+        l = [build_dov_url('data/boring/1986-068853'),
+             build_dov_url('data/boring/1986-068843'),
+             build_dov_url('data/boring/1980-068861')]
+
+        l_modified = [f"%|{build_dov_url('data/boring/1986-068853')}|%",
+                      f"%|{build_dov_url('data/boring/1986-068843')}|%",
+                      f"%|{build_dov_url('data/boring/1980-068861')}|%"]
+
+        df = pd.DataFrame({
+            'pkey_boring': pd.Series(l),
+            'diepte_tot_m': pd.Series([10, 20, 30])
+        })
+
+        query = FuzzyJoin(df, 'pkey_boring')
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/fes/2.0}Or'
+        assert len(list(xml)) == 3
+
+        for f in xml:
+            assert f.tag == '{http://www.opengis.net/fes/2.0}PropertyIsLike'
+
+            valuereference = f.find(
+                './{http://www.opengis.net/fes/2.0}ValueReference')
+            assert valuereference.text == 'pkey_boring'
+
+            literal = f.find('./{http://www.opengis.net/fes/2.0}Literal')
+            assert literal.text in l_modified
+
+            l_modified.remove(literal.text)
+
+        assert len(l_modified) == 0
+
+    def test_duplicate(self):
+        """Test the FuzzyJoin expression with a column containing
+        duplicates.
+
+        Test whether the generated query is correct and does not contain the
+        duplicate entry twice.
+
+        """
+        l = [build_dov_url('data/boring/1986-068853'),
+             build_dov_url('data/boring/1986-068853'),
+             build_dov_url('data/boring/1980-068861')]
+
+        l_output = [f"%|{build_dov_url('data/boring/1986-068853')}|%",
+                    f"%|{build_dov_url('data/boring/1980-068861')}|%"]
+
+        df = pd.DataFrame({
+            'pkey_boring': pd.Series(l),
+            'diepte_tot_m': pd.Series([10, 20, 30])
+        })
+
+        query = FuzzyJoin(df, 'pkey_boring')
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/fes/2.0}Or'
+        assert len(list(xml)) == 2
+
+        for f in xml:
+            assert f.tag == '{http://www.opengis.net/fes/2.0}PropertyIsLike'
+
+            valuereference = f.find(
+                './{http://www.opengis.net/fes/2.0}ValueReference')
+            assert valuereference.text == 'pkey_boring'
+
+            literal = f.find('./{http://www.opengis.net/fes/2.0}Literal')
+            assert literal.text in l_output
+
+            l_output.remove(literal.text)
+
+        assert len(l_output) == 0
+
+    def test_wrongcolumn(self):
+        """Test the FuzzyJoin expression with a join_column not available in the
+        dataframe.
+
+        Test whether a ValueError is raised.
+
+        """
+        with pytest.raises(ValueError):
+            l = [build_dov_url('data/boring/1986-068853'),
+                 build_dov_url('data/boring/1986-068843'),
+                 build_dov_url('data/boring/1980-068861')]
+
+            df = pd.DataFrame({
+                'pkey_boring': pd.Series(l),
+                'diepte_tot_m': pd.Series([10, 20, 30])
+            })
+
+            FuzzyJoin(df, 'pkey_sondering')
+
+    def test_single(self):
+        """Test the FuzzyJoin expression with a dataframe containing a single row.
+
+        Test whether the generated query is correct and does contain only a
+        single PropertyIsLike.
+
+        """
+        l = [build_dov_url('data/boring/1986-068853')]
+        l_output = [f"%|{build_dov_url('data/boring/1986-068853')}|%"]
+
+        df = pd.DataFrame({
+            'pkey_boring': pd.Series(l),
+            'diepte_tot_m': pd.Series([10])
+        })
+
+        query = FuzzyJoin(df, 'pkey_boring')
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/fes/2.0}PropertyIsLike'
+
+        valuereference = xml.find(
+            './{http://www.opengis.net/fes/2.0}ValueReference')
+        assert valuereference.text == 'pkey_boring'
+
+        literal = xml.find('./{http://www.opengis.net/fes/2.0}Literal')
+        assert literal.text in l_output
+
+        l_output.remove(literal.text)
+        assert len(l_output) == 0
+
+    def test_single_duplicate(self):
+        """Test the FuzzyJoin expression with a dataframe containing two
+        identical keys.
+
+        Test whether the generated query is correct and does contain only a
+        single PropertyIsLike.
+
+        """
+        l = [build_dov_url('data/boring/1986-068853'),
+             build_dov_url('data/boring/1986-068853')]
+
+        l_output = [f"%|{build_dov_url('data/boring/1986-068853')}|%"]
+
+        df = pd.DataFrame({
+            'pkey_boring': pd.Series(l),
+            'diepte_tot_m': pd.Series([10, 20])
+        })
+
+        query = FuzzyJoin(df, 'pkey_boring')
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/fes/2.0}PropertyIsLike'
+
+        valuereference = xml.find(
+            './{http://www.opengis.net/fes/2.0}ValueReference')
+        assert valuereference.text == 'pkey_boring'
+
+        literal = xml.find('./{http://www.opengis.net/fes/2.0}Literal')
+        assert literal.text in l_output
+
+        l_output.remove(literal.text)
+        assert len(l_output) == 0
+
+    def test_empty(self):
+        """Test the FuzzyJoin expression with an empty dataframe.
+
+        Test whether a ValueError is raised
+
+        """
+        df = pd.DataFrame({
+            'pkey_boring': [np.nan, np.nan],
+            'diepte_tot_m': pd.Series([10, 20])
+        })
+
+        with pytest.raises(ValueError):
+            FuzzyJoin(df, 'pkey_boring')
+
+    def test_on(self):
+        """Test the FuzzyJoin expression with a standard dataframe and 'on'.
+
+        Test whether the generated query is correct.
+
+        """
+        l = [build_dov_url('data/boring/1986-068853'),
+             build_dov_url('data/boring/1986-068843'),
+             build_dov_url('data/boring/1980-068861')]
+
+        l_modified = [f"%|{build_dov_url('data/boring/1986-068853')}|%",
+                      f"%|{build_dov_url('data/boring/1986-068843')}|%",
+                      f"%|{build_dov_url('data/boring/1980-068861')}|%"]
+
+        df = pd.DataFrame({
+            'pkey_boring': pd.Series(l),
+            'diepte_tot_m': pd.Series([10, 20, 30])
+        })
+
+        query = FuzzyJoin(df, on='pkey_boring')
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/fes/2.0}Or'
+        assert len(list(xml)) == 3
+
+        for f in xml:
+            assert f.tag == '{http://www.opengis.net/fes/2.0}PropertyIsLike'
+
+            valuereference = f.find(
+                './{http://www.opengis.net/fes/2.0}ValueReference')
+            assert valuereference.text == 'pkey_boring'
+
+            literal = f.find('./{http://www.opengis.net/fes/2.0}Literal')
+            assert literal.text in l_modified
+
+            l_modified.remove(literal.text)
+
+        assert len(l_modified) == 0
+
+    def test_using(self):
+        """Test the Join expression with a standard dataframe and 'on' and
+        'using'.
+
+        Test whether the generated query is correct.
+
+        """
+        l = [build_dov_url('data/boring/1986-068853'),
+             build_dov_url('data/boring/1986-068843'),
+             build_dov_url('data/boring/1980-068861')]
+
+        l_modified = [f"%|{build_dov_url('data/boring/1986-068853')}|%",
+                      f"%|{build_dov_url('data/boring/1986-068843')}|%",
+                      f"%|{build_dov_url('data/boring/1980-068861')}|%"]
+
+        df = pd.DataFrame({
+            'boringfiche': pd.Series(l),
+            'diepte_tot_m': pd.Series([10, 20, 30])
+        })
+
+        query = FuzzyJoin(df, on='pkey_boring', using='boringfiche')
+        xml = query.toXML()
+
+        assert xml.tag == '{http://www.opengis.net/fes/2.0}Or'
+        assert len(list(xml)) == 3
+
+        for f in xml:
+            assert f.tag == '{http://www.opengis.net/fes/2.0}PropertyIsLike'
+
+            valuereference = f.find(
+                './{http://www.opengis.net/fes/2.0}ValueReference')
+            assert valuereference.text == 'pkey_boring'
+
+            literal = f.find('./{http://www.opengis.net/fes/2.0}Literal')
+            assert literal.text in l_modified
+
+            l_modified.remove(literal.text)
+
+        assert len(l_modified) == 0


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Introduce PropertyLikeList and FuzzyJoin query utilities to search for, and join on, fuzzy (non-exact) matches.

This is part of upcoming changes for the Grondmonster type, where a Grondmonster will (possibly) have multiple parents.

This change will allow to search on the aggregated field of the new Grondmonster service with another output dataframe with pkey's, using the new FuzzyJoin operator.
