### PR TITLE
Add support for splitting field values into a list of values.

### DIFF
--- a/pydov/types/fields.py
+++ b/pydov/types/fields.py
@@ -25,7 +25,7 @@ class AbstractField(dict):
     """Abstract base class for pydov field definitions. Not to be
     instantiated directly."""
 
-    def __init__(self, name, source, datatype, **kwargs):
+    def __init__(self, name, source, datatype, split_fn=None, **kwargs):
         """Initialise a field.
 
         Parameters
@@ -37,18 +37,21 @@ class AbstractField(dict):
         datatype : one of 'string', 'integer', 'float', 'date', 'datetime' \
                    or 'boolean'
             Datatype of the values of this field in the return dataframe.
+        split_fn : optional, function
+            Function to split values from this field into a list of values.
 
         """
         super(AbstractField, self).__init__(**kwargs)
         self.__setitem__('name', name)
         self.__setitem__('source', source)
         self.__setitem__('type', datatype)
+        self.__setitem__('split_fn', split_fn)
 
 
 class WfsField(AbstractField):
     """Class for a field available in the WFS service."""
 
-    def __init__(self, name, source_field, datatype):
+    def __init__(self, name, source_field, datatype, split_fn=None):
         """Initialise a WFS field.
 
         Parameters
@@ -60,9 +63,11 @@ class WfsField(AbstractField):
         datatype : one of 'string', 'integer', 'float', 'date', 'datetime' \
                    or 'boolean'
             Datatype of the values of this field in the return dataframe.
+        split_fn : optional, function
+            Function to split values from this field into a list of values.
 
         """
-        super(WfsField, self).__init__(name, 'wfs', datatype)
+        super(WfsField, self).__init__(name, 'wfs', datatype, split_fn)
         self.__setitem__('sourcefield', source_field)
 
 

--- a/pydov/types/interpretaties.py
+++ b/pydov/types/interpretaties.py
@@ -125,7 +125,8 @@ class AbstractBoringInterpretatie(AbstractDovType):
                 func=feature.findtext,
                 xpath=field['sourcefield'],
                 namespace=namespace,
-                returntype=field.get('type', None)
+                returntype=field.get('type', None),
+                split_fn=field.get('split_fn', None)
             )
 
         return instance

--- a/tests/abstract.py
+++ b/tests/abstract.py
@@ -799,11 +799,11 @@ class AbstractTestTypes(object):
             if field['source'] == 'wfs':
                 if 'wfs_injected' in field.keys():
                     assert sorted(field.keys()) == [
-                        'name', 'source', 'sourcefield', 'type',
+                        'name', 'source', 'sourcefield', 'split_fn', 'type',
                         'wfs_injected']
                 else:
                     assert sorted(field.keys()) == [
-                        'name', 'source', 'sourcefield', 'type']
+                        'name', 'source', 'sourcefield', 'split_fn', 'type']
             elif field['source'] == 'xml':
                 assert 'definition' in field
                 assert isinstance(field['definition'], str)
@@ -814,11 +814,12 @@ class AbstractTestTypes(object):
                 if 'xsd_type' in field:
                     assert sorted(field.keys()) == [
                         'definition', 'name', 'notnull', 'source',
-                        'sourcefield', 'type', 'xsd_schema', 'xsd_type']
+                        'sourcefield', 'split_fn', 'type', 'xsd_schema',
+                        'xsd_type']
                 else:
                     assert sorted(field.keys()) == [
                         'definition', 'name', 'notnull', 'source',
-                        'sourcefield', 'type']
+                        'sourcefield', 'split_fn', 'type']
 
     def test_get_fields_nosubtypes(self):
         """Test the get_fields method not including subtypes.


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

This is part of upcoming changes for the Grondmonster type, where a Grondmonster will (possibly) have multiple parents.

This change will allow to parse the contents of the aggregated field into a list of separate pkey's in the output dataframe. Which in turn will allow to use this output dataframe as input for further searches using e.g. a Join operator.
