### PR TITLE
Fix coordinate order (backport to 3.3.0)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,8 @@ v3.3.0
 
   - Update grondmonster type based on WFS/XSD schema updates. (#408)
 
+  - Always request geometry using urn:ogc: srsName to fix coordinate ordering. (#413, #418)
+
 
 v3.2.0
 ------

--- a/pydov/util/owsutil.py
+++ b/pydov/util/owsutil.py
@@ -2,6 +2,7 @@
 """Module grouping utility functions for OWS services."""
 import warnings
 from urllib.parse import urlparse
+import re
 
 from owslib.etree import etree
 from owslib.fes2 import BinaryLogicOpType, UnaryLogicOpType
@@ -25,6 +26,8 @@ def __get_namespaces():
 
 
 __namespaces = __get_namespaces()
+
+re_epsg = re.compile(r'^EPSG:[1-9]+[0-9]*')
 
 
 def has_geom_support():
@@ -435,10 +438,10 @@ def wfs_build_getfeature_request(typename, geometry_column=None, location=None,
         if not isinstance(crs, str):
             raise TypeError('crs should be a string starting with "EPSG"')
 
-        if not crs.lower().startswith('epsg'):
-            raise ValueError('crs should start with "EPSG"')
+        if not re_epsg.match(crs):
+            raise ValueError('crs should match the format "EPSG:1234"')
 
-        query.set('srsName', crs)
+        query.set('srsName', f'urn:ogc:def:crs:{crs.replace(":", "::")}')
 
     if propertyname and len(propertyname) > 0:
         for property in sorted(propertyname):

--- a/tests/test_search_boring.py
+++ b/tests/test_search_boring.py
@@ -1,12 +1,14 @@
 """Module grouping tests for the boring search module."""
 import datetime
 
+import pytest
+
 from owslib.fes2 import PropertyIsEqualTo
 
 from pydov.search.boring import BoringSearch
 from pydov.types.boring import Boring
-from pydov.types.fields import ReturnFieldList
-from tests.abstract import AbstractTestSearch
+from pydov.types.fields import GeometryReturnField, ReturnFieldList
+from tests.abstract import AbstractTestSearch, ServiceCheck
 
 location_md_metadata = 'tests/data/types/boring/md_metadata.xml'
 location_fc_featurecatalogue = \
@@ -35,7 +37,8 @@ class TestBoringSearch(AbstractTestSearch):
                                                           'datum_aanvang')
     valid_returnfields_subtype = ReturnFieldList.from_field_names('pkey_boring', 'boornummer',
                                                                   'diepte_methode_van', 'diepte_methode_tot')
-    valid_returnfields_extra = ReturnFieldList.from_field_names('pkey_boring', 'doel')
+    valid_returnfields_extra = ReturnFieldList.from_field_names(
+        'pkey_boring', 'doel')
 
     df_default_columns = ['pkey_boring', 'boornummer', 'x', 'y', 'mv_mtaw',
                           'start_boring_mtaw', 'gemeente',
@@ -130,3 +133,37 @@ class TestBoringSearch(AbstractTestSearch):
             return_fields=('pkey_boring', 'boornummer', 'boorgatmeting'))
 
         assert not df.boorgatmeting[0]
+
+    @pytest.mark.online
+    @pytest.mark.skipif(not ServiceCheck.service_ok(),
+                        reason="DOV service is unreachable")
+    def test_geometry_coordinate_order_4326(self):
+        """Test whether the order of the returned coordinates is correct for
+        the EPSG:4326 coordinate system.
+
+        """
+        df = self.search_instance.search(
+            query=self.valid_query_single,
+            return_fields=[
+                'pkey_boring', GeometryReturnField('geom', 4326)]
+        )
+
+        assert round(df.geom.iloc[0].x, 2) == 4.39
+        assert round(df.geom.iloc[0].y, 2) == 51.24
+
+    @pytest.mark.online
+    @pytest.mark.skipif(not ServiceCheck.service_ok(),
+                        reason="DOV service is unreachable")
+    def test_geometry_coordinate_order_31370(self):
+        """Test whether the order of the returned coordinates is correct for
+        the EPSG:31370 coordinate system.
+
+        """
+        df = self.search_instance.search(
+            query=self.valid_query_single,
+            return_fields=[
+                'pkey_boring', GeometryReturnField('geom', 31370)]
+        )
+
+        assert round(df.geom.iloc[0].x, 2) == 151680.75
+        assert round(df.geom.iloc[0].y, 2) == 214678.06

--- a/tests/test_util_owsutil.py
+++ b/tests/test_util_owsutil.py
@@ -660,8 +660,8 @@ class TestWfsGetFeatureRequest(object):
             'service="WFS" version="2.0.0" startIndex="0" '
             'xsi:schemaLocation="http://www.opengis.net/wfs/2.0 '
             'http://schemas.opengis.net/wfs/2.0/wfs.xsd"><wfs:Query '
-            'typeNames="dov-pub:Boringen" srsName="EPSG:31370"/></wfs'
-            ':GetFeature>')
+            'typeNames="dov-pub:Boringen" '
+            'srsName="urn:ogc:def:crs:EPSG::31370"/></wfs:GetFeature>')
 
     def test_wfs_build_getfeature_request_srs_wrongtype(self):
         """Test the owsutil.wfs_build_getfeature_request method with only a


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have read and followed the guidelines in the `CONTRIBUTING` document
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Backport the coordinate order fix to 3.3.0 branch
